### PR TITLE
use the correct node label (networkmanager) so the jobs get run in the correct workspace

### DIFF
--- a/run/centos-ci/nm-centosci.yml
+++ b/run/centos-ci/nm-centosci.yml
@@ -3,7 +3,7 @@
     project-type: freestyle
     display-name: 'NetworkManager: {branch}'
     concurrent: true
-    node: component
+    node: networkmanager
     triggers:
         - timed: "H 18 * * *"
     scm:


### PR DESCRIPTION
The workspace will always be labeled 'networkmanager' no matter which physical machine it lands on. We should use that for each of the jobs.