### PR TITLE
Add new "netservice" tag to collect network.service journal logs

### DIFF
--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -954,6 +954,13 @@ def after_scenario(context, scenario):
         else:
             print("WARNING: 20M size exceeded in /tmp/network-traffic.log, skipping")
 
+        if 'netservice' in scenario.tags:
+            # Attach network.service journalctl logs
+            os.system("sudo journalctl -u network --no-pager -o cat %s > /tmp/journal-netsrv.log" % context.log_cursor)
+            data = open("/tmp/journal-netsrv.log", 'r').read()
+            if data:
+                context.embed('text/plain', data)
+
         if 'runonce' in scenario.tags:
             print ("---------------------------")
             print ("delete profiles and start NM")

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -994,7 +994,7 @@ Feature: nmcli - general
 
     @rhbz1182085
     @ver+=1.4
-    @long
+    @long @netservice
     @nmcli_general_profile_pickup_doesnt_break_network
     Scenario: nmcli - general - profile pickup does not break network service
     * Add a new connection of type "ethernet" and options "ifname * con-name ethernet0"


### PR DESCRIPTION
This is needed to understand the nature of the rare failures occurring in "profile pickup does not break network service" test: there network service restart fails and we need to have journal logs when this happens (see [rh bz 1455134](https://bugzilla.redhat.com/show_bug.cgi?id=1455134)).