### PR TITLE
ipv6: add explicit route to server in @ipv6_preserve_cached_routes

### DIFF
--- a/nmcli/features/ipv6.feature
+++ b/nmcli/features/ipv6.feature
@@ -1095,6 +1095,7 @@ Feature: nmcli: ipv6
     * Prepare simulated test "testX" device for IPv6 PMTU discovery
     * Add a new connection of type "ethernet" and options "ifname testX con-name ethernet0 autoconnect no"
     * Execute "nmcli con modify ethernet0 ipv4.method disabled ipv6.method auto"
+    * Execute "nmcli con modify ethernet0 ipv6.routes 'fd02::/64 fd01::1'"
     * Execute "ip l set testX up"
     * Bring "up" connection "ethernet0"
     * Execute "dd if=/dev/zero bs=1M count=10 | nc fd02::2 8080"


### PR DESCRIPTION
Otherwise fd02::2 will be contacted on the wrong interface if there is
an existing default IPv6 route with lower metric.

Fixes: 98fef041b412ee803ecae651b9bc9fb9c0bb25ec