### PR TITLE
Make the script more robust

### DIFF
--- a/prepare/racoon.sh
+++ b/prepare/racoon.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+# Allow only users with root priviledge to run the script.
+if [ $EUID -ne 0 ]; then
+    echo "This script can be run with root priviledge only." >&2
+    exit 1
+fi
+
+# Check for the correct # of arguments:
+USAGE_INFO="Usage: $0 mode dh_group phase1_algorithm | teardown"
+
+if [ $# -lt 3 ] && [ "$1" != 'teardown' ]; then
+    echo "Error. Not enough arguments (3 required)." >&2
+    echo "$USAGE_INFO" >&2
+    exit 1
+elif [ $# -gt 3 ]; then
+    echo "Error. Too many arguments (3 required).\n" >&2
+    echo "$USAGE_INFO" >&2
+    exit 1
+else
+    echo "Starting racoon.sh..."
+fi
+
+
 function racoon_setup ()
 {
     # Quit immediatelly on any script error
@@ -8,16 +30,16 @@ function racoon_setup ()
     DH_GROUP=$2
     PHASE1_AL=$3
     RACOON_DIR="/etc/racoon"
-    RACOON_CFG="/etc/racoon/racoon.conf"
+    RACOON_CFG="$RACOON_DIR/racoon.conf"
     echo "Configuring VPN server Racoon..."
-    [ -d $RACOON_DIR ] || sudo mkdir $RACOON_DIR
-    [ -f $RACOON_CFG ] || sudo touch $RACOON_CFG
+    [ -d $RACOON_DIR ] || mkdir $RACOON_DIR
+    [ -f $RACOON_CFG ] || touch $RACOON_CFG
 
     echo "# Racoon configuration for Libreswan client testing
-    path include \"/etc/racoon\";
-    path pre_shared_key \"/etc/racoon/psk.txt\";
-    path certificate \"/etc/racoon/certs\";
-    path script \"/etc/racoon/scripts\";
+    path include \"$RACOON_DIR\";
+    path pre_shared_key \"$RACOON_DIR/psk.txt\";
+    path certificate \"$RACOON_DIR/certs\";
+    path script \"$RACOON_DIR/scripts\";
 
     sainfo anonymous {
             encryption_algorithm aes;
@@ -58,9 +80,9 @@ function racoon_setup ()
     # random characters and have a length of at least 20 characters. Due to the dangers of
     # non-random and short PSKs, this method is not available when the system is running in
     # FIPS mode.
-    echo "172.31.70.2 ipsecret" > /etc/racoon/psk.txt
+    echo "172.31.70.2 ipsecret" > $RACOON_DIR/psk.txt
     for i in {3..41}; do
-        echo "172.31.70.$i ipsecret" >> /etc/racoon/psk.txt
+        echo "172.31.70.$i ipsecret" >> $RACOON_DIR/psk.txt
     done
 
     if getent passwd budulinek > /dev/null; then
@@ -132,14 +154,16 @@ function racoon_setup ()
 
 function racoon_teardown ()
 {
-    sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/default/disable_ipv6'
-    sudo kill -INT $(ps aux|grep dns|grep racoon|grep -v grep |awk {'print $2'})
-    sudo systemctl stop nm-racoon
-    sudo systemctl reset-failed nm-racoon
-    sudo ip netns del racoon
-    sudo ip link del racoon1
-    sudo nmcli con del rac1
-    sudo modprobe -r ip_vti
+    echo 0 > /proc/sys/net/ipv6/conf/default/disable_ipv6
+    kill -INT $(ps aux|grep dns|grep racoon|grep -v grep |awk {'print $2'})
+    if systemctl --quiet is-active nm-racoon; then
+        systemctl stop nm-racoon
+        systemctl reset-failed nm-racoon
+    fi
+    ip netns del racoon
+    ip link del racoon1
+    nmcli connection del rac1
+    modprobe -r ip_vti
 }
 
 if [ "$1" != "teardown" ]; then

--- a/prepare/racoon.sh
+++ b/prepare/racoon.sh
@@ -158,6 +158,8 @@ function racoon_teardown ()
     kill -INT $(ps aux|grep dns|grep racoon|grep -v grep |awk {'print $2'})
     if systemctl --quiet is-active nm-racoon; then
         systemctl stop nm-racoon
+    fi
+    if systemctl --quiet is-failed nm-racoon; then
         systemctl reset-failed nm-racoon
     fi
     ip netns del racoon


### PR DESCRIPTION
1. Check for number of parameters.
2. Make runnable for users with root priv. Remove "sudo" keywords from the script.
3. Replace all occurrences of /etc/racoon with $RACOON_DIR