### PR TITLE
tui: adjust tests for guessing address prefix

### DIFF
--- a/nmtui/features/ipv4.feature
+++ b/nmtui/features/ipv4.feature
@@ -15,6 +15,7 @@ Feature: IPv4 TUI tests
 
 
     @ipv4
+    @ver-=1.9.1
     @nmtui_ipv4_addresses_static_no_mask
     Scenario: nmtui - ipv4 - addresses - static IPv4 without netmask
     * Prepare new connection of type "Ethernet" named "ethernet"
@@ -24,6 +25,19 @@ Feature: IPv4 TUI tests
     * In "Addresses" property add "192.168.1.10"
     * Confirm the connection settings
     Then "inet 192.168.1.10/32" is visible with command "ip a s eth1" in "10" seconds
+    Then "eth1\s+ethernet\s+connected\s+ethernet" is visible with command "nmcli device"
+
+    @ipv4
+    @ver+=1.9.2
+    @nmtui_ipv4_addresses_static_no_mask
+    Scenario: nmtui - ipv4 - addresses - static IPv4 without netmask
+    * Prepare new connection of type "Ethernet" named "ethernet"
+    * Set "Device" field to "eth1"
+    * Set "IPv4 CONFIGURATION" category to "Manual"
+    * Come in "IPv4 CONFIGURATION" category
+    * In "Addresses" property add "192.168.1.10"
+    * Confirm the connection settings
+    Then "inet 192.168.1.10/24" is visible with command "ip a s eth1" in "10" seconds
     Then "eth1\s+ethernet\s+connected\s+ethernet" is visible with command "nmcli device"
 
 

--- a/nmtui/features/ipv6.feature
+++ b/nmtui/features/ipv6.feature
@@ -16,6 +16,7 @@ Feature: IPv6 TUI tests
 
 
     @ipv6
+    @ver-=1.9.1
     @nmtui_ipv6_addresses_static_no_mask
     Scenario: nmtui - ipv6 - addresses - static IPv6 configuration without netmask
     * Prepare new connection of type "Ethernet" named "ethernet"
@@ -27,6 +28,20 @@ Feature: IPv6 TUI tests
     * Confirm the connection settings
     Then "eth1\s+ethernet\s+connected\s+ethernet" is visible with command "nmcli device" in "10" seconds
     Then "inet6 2607:f0d0:1002:51::4/128" is visible with command "ip -6 a s eth1"
+
+    @ipv6
+    @ver+=1.9.2
+    @nmtui_ipv6_addresses_static_no_mask
+    Scenario: nmtui - ipv6 - addresses - static IPv6 configuration without netmask
+    * Prepare new connection of type "Ethernet" named "ethernet"
+    * Set "Device" field to "eth1"
+    * Set "IPv4 CONFIGURATION" category to "Disabled"
+    * Set "IPv6 CONFIGURATION" category to "Manual"
+    * Come in "IPv6 CONFIGURATION" category
+    * In "Addresses" property add "2607:f0d0:1002:51::4"
+    * Confirm the connection settings
+    Then "eth1\s+ethernet\s+connected\s+ethernet" is visible with command "nmcli device" in "10" seconds
+    Then "inet6 2607:f0d0:1002:51::4/64" is visible with command "ip -6 a s eth1"
 
 
     @ipv6


### PR DESCRIPTION
Since NetworkManager commit 08d7bf5988173f8569b17c646eb1a5c5d9d9340c,
rh#1474295, nmtui guesses the address prefix for RFC1918 private addresses
and uses by default a /64 prefix for IPv6 addresses.


Fix tests `@nmtui_ipv4_addresses_static_no_mask` and `@nmtui_ipv6_addresses_static_no_mask`  for master.