### PR TITLE
adjust tests for route metric of default route (th/platform-route-pt4)

### DIFF
--- a/nmcli/features/connection.feature
+++ b/nmcli/features/connection.feature
@@ -407,6 +407,7 @@ Feature: nmcli: connection
 
 
     @rhbz663730
+    @ver-=1.9.1
     @con @eth @connect_testeth0
     @route_priorities
     Scenario: nmcli - connection - route priorities
@@ -426,6 +427,28 @@ Feature: nmcli: connection
      * Bring "up" connection "connie"
      When "metric 100" is visible with command "ip r |grep default |grep eth0"
      When "metric 101" is visible with command "ip r |grep default |grep eth10"
+
+    @rhbz663730
+    @ver+=1.9.2
+    @con @eth @connect_testeth0
+    @route_priorities
+    Scenario: nmcli - connection - route priorities
+     * Add a new connection of type "ethernet" and options "ifname eth0 con-name ethie autoconnect no"
+     * Add a new connection of type "ethernet" and options "ifname eth10 con-name connie autoconnect no"
+     * Execute "nmcli con modify ethie ipv4.may-fail no"
+     * Execute "nmcli con modify connie ipv4.may-fail no"
+     * Bring "up" connection "ethie"
+     * Bring "up" connection "connie"
+     When "metric 100" is visible with command "ip r |grep default |grep eth0"
+     When "metric 100" is visible with command "ip r |grep default |grep eth10"
+     * Execute "nmcli con modify connie ipv4.route-metric 10"
+     * Bring "up" connection "connie"
+     When "metric 100" is visible with command "ip r |grep default |grep eth0"
+     When "metric 10" is visible with command "ip r |grep default |grep eth10"
+     * Execute "nmcli con modify connie ipv4.route-metric -1"
+     * Bring "up" connection "connie"
+     When "metric 100" is visible with command "ip r |grep default |grep eth0"
+     When "metric 100" is visible with command "ip r |grep default |grep eth10"
 
 
     @rhbz663730

--- a/nmtui/features/ipv4.feature
+++ b/nmtui/features/ipv4.feature
@@ -233,6 +233,7 @@ Feature: IPv4 TUI tests
 
 
     @ipv4
+    @ver-=1.9.1
     @nmtui_ipv4_routes_several_default_routes_metrics
     Scenario: nmtui - ipv4 - addresses - several default gateways and metrics
     * Prepare new connection of type "Ethernet" named "ethernet1"
@@ -255,6 +256,33 @@ Feature: IPv4 TUI tests
     Then "192.168.10.2/24" is visible with command "ip a s eth2" in "10" seconds
     Then "default via 192.168.5.1 dev eth1\s+proto static\s+metric 101" is visible with command "ip -4 route"
     Then "default via 192.168.10.1 dev eth2\s+proto static\s+metric 102" is visible with command "ip -4 route"
+    Then "192.168.5.0/24 dev eth1\s+proto kernel\s+scope link\s+src 192.168.5.2" is visible with command "ip -4 route"
+    Then "192.168.10.0/24 dev eth2\s+proto kernel\s+scope link\s+src 192.168.10.2" is visible with command "ip -4 route"
+
+    @ipv4
+    @ver+=1.9.2
+    @nmtui_ipv4_routes_several_default_routes_metrics
+    Scenario: nmtui - ipv4 - addresses - several default gateways and metrics
+    * Prepare new connection of type "Ethernet" named "ethernet1"
+    * Set "Device" field to "eth1"
+    * Set "IPv4 CONFIGURATION" category to "Manual"
+    * Come in "IPv4 CONFIGURATION" category
+    * In "Addresses" property add "192.168.5.2/24"
+    * Set "Gateway" field to "192.168.5.1"
+    * Confirm the connection settings
+    * Choose to "<Add>" a connection
+    * Choose the connection type "Ethernet"
+    * Set "Profile name" field to "ethernet2"
+    * Set "Device" field to "eth2"
+    * Set "IPv4 CONFIGURATION" category to "Manual"
+    * Come in "IPv4 CONFIGURATION" category
+    * In "Addresses" property add "192.168.10.2/24"
+    * Set "Gateway" field to "192.168.10.1"
+    * Confirm the connection settings
+    Then "192.168.5.2/24" is visible with command "ip a s eth1" in "10" seconds
+    Then "192.168.10.2/24" is visible with command "ip a s eth2" in "10" seconds
+    Then "default via 192.168.5.1 dev eth1\s+proto static\s+metric 100" is visible with command "ip -4 route"
+    Then "default via 192.168.10.1 dev eth2\s+proto static\s+metric 100" is visible with command "ip -4 route"
     Then "192.168.5.0/24 dev eth1\s+proto kernel\s+scope link\s+src 192.168.5.2" is visible with command "ip -4 route"
     Then "192.168.10.0/24 dev eth2\s+proto kernel\s+scope link\s+src 192.168.10.2" is visible with command "ip -4 route"
 

--- a/nmtui/features/ipv6.feature
+++ b/nmtui/features/ipv6.feature
@@ -247,6 +247,7 @@ Feature: IPv6 TUI tests
 
     @ipv6
     @eth0
+    @ver-=1.9.1
     @nmtui_ipv6_routes_several_default_routes_metrics
     Scenario: nmtui - ipv6 - addresses - several default gateways and metrics
     * Prepare new connection of type "Ethernet" named "ethernet1"
@@ -269,6 +270,35 @@ Feature: IPv6 TUI tests
     Then "inet6 fc05::1:5/68" is visible with command "ip a s eth2" in "10" seconds
     Then "default via fc01::1:1 dev eth1\s+proto static\s+metric 100" is visible with command "ip -6 route" in "10" seconds
     Then "default via fc05::1:1 dev eth2\s+proto static\s+metric 101" is visible with command "ip -6 route" in "10" seconds
+    Then "fc01::/68 dev eth1\s+proto kernel" is visible with command "ip -6 route" in "10" seconds
+    Then "fc05::/68 dev eth2\s+proto kernel" is visible with command "ip -6 route" in "10" seconds
+
+
+    @ipv6
+    @eth0
+    @ver+=1.9.2
+    @nmtui_ipv6_routes_several_default_routes_metrics
+    Scenario: nmtui - ipv6 - addresses - several default gateways and metrics
+    * Prepare new connection of type "Ethernet" named "ethernet1"
+    * Set "Device" field to "eth1"
+    * Set "IPv6 CONFIGURATION" category to "Manual"
+    * Come in "IPv6 CONFIGURATION" category
+    * In "Addresses" property add "fc01::1:5/68"
+    * Set "Gateway" field to "fc01::1:1"
+    * Confirm the connection settings
+    * Choose to "<Add>" a connection
+    * Choose the connection type "Ethernet"
+    * Set "Profile name" field to "ethernet2"
+    * Set "Device" field to "eth2"
+    * Set "IPv6 CONFIGURATION" category to "Manual"
+    * Come in "IPv6 CONFIGURATION" category
+    * In "Addresses" property add "fc05::1:5/68"
+    * Set "Gateway" field to "fc05::1:1"
+    * Confirm the connection settings
+    Then "inet6 fc01::1:5/68" is visible with command "ip a s eth1" in "10" seconds
+    Then "inet6 fc05::1:5/68" is visible with command "ip a s eth2" in "10" seconds
+    Then "default via fc01::1:1 dev eth1\s+proto static\s+metric 100" is visible with command "ip -6 route" in "10" seconds
+    Then "default via fc05::1:1 dev eth2\s+proto static\s+metric 100" is visible with command "ip -6 route" in "10" seconds
     Then "fc01::/68 dev eth1\s+proto kernel" is visible with command "ip -6 route" in "10" seconds
     Then "fc05::/68 dev eth2\s+proto kernel" is visible with command "ip -6 route" in "10" seconds
 


### PR DESCRIPTION
Previously, NetworkManager would configure default routes via `ip route replace`.
That meant, it needed to take care about not to configure the same dst/plen,metric
route on multiple interfaces, because they would conflict and replace each other.
That was solved by having a NMDefaultRouteManager which corrdinates configuring the
default routes. In face of duplicate routes, it would then bump the metric to avoid
the conflict.

Now, we use instead `ip route append` and each interface can hold conflicting routes
just fine. That makes the bumping of the route no longer necessary. Adjust tests for that.

This adjusts the tests for https://github.com/NetworkManager/NetworkManager/pull/26 . This is already merged on master, so this fixes expected 3 failures there.