### PR TITLE
env: move install of ppp subpackage to env

### DIFF
--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -678,6 +678,8 @@ def before_scenario(context, scenario):
         if 'pppoe' in scenario.tags:
             print ("---------------------------")
             print ("installing pppoe dependencies")
+            # This -x is to avoid upgrade of NetworkManager in older version testing
+            call("yum -y install NetworkManager-ppp -x NetworkManager", shell=True)
             call('yum -y install rp-pppoe', shell=True)
 
         if 'nmcli_general_dhcp_profiles_general_gateway' in scenario.tags:

--- a/prepare/devsetup.sh
+++ b/prepare/devsetup.sh
@@ -13,7 +13,7 @@ local_setup_configure_nm_eth () {
     echo "networkmanager" | passwd test --stdin
 
     #adding ntp and syncing time
-    yum -y install dnsmasq ntp tcpdump NetworkManager-libreswan wireshark NetworkManager-ppp bridge-utils
+    yum -y install dnsmasq ntp tcpdump NetworkManager-libreswan wireshark bridge-utils
 
     service ntpd restart
 


### PR DESCRIPTION
We need to avoid installing NM-ppp as it can pull in new NM and that
is not correct in case of older version testing.