### PR TITLE
ipv6: make slaac addressing to match different lab too

### DIFF
--- a/nmcli/features/ipv6.feature
+++ b/nmcli/features/ipv6.feature
@@ -359,8 +359,8 @@ Feature: nmcli: ipv6
      * Add a new connection of type "ethernet" and options "ifname eth10 con-name ethie autoconnect no"
      * Execute "nmcli connection modify ethie ipv6.may-fail no"
      * Bring "up" connection "ethie"
-    Then "2620:52:0:1086::/64 dev eth10\s+proto ra" is visible with command "ip -6 r" in "20" seconds
-    Then "2620:52:0:1086" is visible with command "ip -6 a s eth10 |grep 'global noprefix'" in "20" seconds
+    Then "2620:52:0:.*::/64 dev eth10\s+proto ra" is visible with command "ip -6 r" in "20" seconds
+    Then "2620:52:0:" is visible with command "ip -6 a s eth10 |grep 'global noprefix'" in "20" seconds
 
 
     @ipv6 @eth0 @long


### PR DESCRIPTION
We have few labs but correct prefix is just 2620:52:0 as the rest
may be different from 1086 over 1311 to even different areas.