### PR TITLE
environment: add a sleep after starting firewalld service

### DIFF
--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -471,7 +471,9 @@ def before_scenario(context, scenario):
             call("sudo systemctl unmask firewalld", shell=True)
             call("sudo systemctl start firewalld", shell=True)
             call("sudo nmcli con modify testeth0 connection.zone public", shell=True)
-            #call("sleep 4", shell=True)
+            # Add a sleep here to prevent firewalld to hang
+            # (see https://bugzilla.redhat.com/show_bug.cgi?id=1495893)
+            call("sleep 1", shell=True)
 
         if ('ethernet' in scenario.tags) or ('bridge' in scenario.tags) or ('vlan' in scenario.tags):
             print ("---------------------------")


### PR DESCRIPTION
this is required to avoid hanging of firewall-cmd: a combination of
start/restart/stop of firewalld service with the "right" timing could
cause the service to hang.
This would cause many test failures due to test timeout:
- no_error_when_firewald_restarted
- show_zones_after_firewalld_install
- connectivity_check
- disable_connectivity_check
- ...
and other failures as NM will try to contact firewalld during connection
activations and will wait 10 seconds for firewalld before giving up and
proceding in the connection activation: in many tests a delay of 10
seconds while connection activation is too much, triggering the test
failure. Some affected tests:
- snapshot_rollback
- snapshot_rollback_all_devices
- snapshot_rollback_all_devices_with_timeout
- snapshot_rollback_soft_device
- alias_ifcfg_reboo- ...

https://bugzilla.redhat.com/show_bug.cgi?id=1495893