### PR TITLE
steps: disable readline pager when testing autocompletion

### DIFF
--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -1196,6 +1196,7 @@ def check_pattern_not_visible_with_command(context, pattern, command):
 
 @step(u'"{pattern}" is visible with tab after "{command}"')
 def check_pattern_visible_with_tab_after_command(context, pattern, command):
+    os.system('echo "set page-completions off" > ~/.inputrc')
     exp = pexpect.spawn('/bin/bash', logfile=context.log)
     exp.send(command)
     exp.sendcontrol('i')
@@ -1208,6 +1209,7 @@ def check_pattern_visible_with_tab_after_command(context, pattern, command):
 
 @step(u'"{pattern}" is not visible with tab after "{command}"')
 def check_pattern_not_visible_with_tab_after_command(context, pattern, command):
+    os.system('echo "set page-completions off" > ~/.inputrc')
     exp = pexpect.spawn('/bin/bash', logfile=context.log)
     exp.send(command)
     exp.sendcontrol('i')


### PR DESCRIPTION
Disable the pager built into readline when testing autocompletion, otherwise pexpect will read only part of the possible completions.

This fixes test 'connection_help'.

Vladimir, please adjust this as you prefer, for example by setting the variable in the global initialization.