### PR TITLE
bond: ensure bond options are in alphabetical order

### DIFF
--- a/nmcli/features/bond.feature
+++ b/nmcli/features/bond.feature
@@ -1209,6 +1209,7 @@
 
 
     @rhbz1299103 @rhbz1348198
+    @ver-=1.10.0
     @slaves @bond
     @bond_set_active_backup_options
     Scenario: nmcli - bond - set active backup options
@@ -1222,6 +1223,20 @@
       And "3" is visible with command "cat /sys/class/net/nm-bond/bonding/num_grat_arp"
       And "3" is visible with command "cat /sys/class/net/nm-bond/bonding/num_unsol_na"
 
+    @rhbz1299103 @rhbz1348198
+    @ver+=1.10.1
+    @slaves @bond
+    @bond_set_active_backup_options
+    Scenario: nmcli - bond - set active backup options
+     * Add a new connection of type "bond" and options "con-name bond0 ifname nm-bond autoconnect no -- connection.autoconnect-slaves 1 bond.options mode=active-backup,active_slave=eth2,num_grat_arp=3,num_unsol_na=3"
+     * Add a new connection of type "ethernet" and options "con-name bond0.1 ifname eth2 master nm-bond autoconnect no"
+     * Add a new connection of type "ethernet" and options "con-name bond0.0 ifname eth1 master nm-bond autoconnect no"
+     * Bring "up" connection "bond0"
+     When "nm-bond:connected:bond0" is visible with command "nmcli -t -f DEVICE,STATE,CONNECTION device" in "20" seconds
+     Then "BONDING_OPTS=\"active_slave=eth2 mode=active-backup num_grat_arp=3 num_unsol_na=3\"" is visible with command "cat /etc/sysconfig/network-scripts/ifcfg-bond0"
+      #And "Currently Active Slave: eth2" is visible with command "cat /proc/net/bonding/nm-bond"
+      And "3" is visible with command "cat /sys/class/net/nm-bond/bonding/num_grat_arp"
+      And "3" is visible with command "cat /sys/class/net/nm-bond/bonding/num_unsol_na"
 
     @rhbz1299103
     @slaves @bond


### PR DESCRIPTION
Before 1.10.1 the order of bond options was undefined (it was actually
the same in most cases, but it depended on the internal hash function
used by NM). Since 1.10.1 we guarantee that options are returned in
alphabetical order.