### PR TITLE
Add new test scenarios for ModemManager

### DIFF
--- a/nmcli/features/gsm.feature
+++ b/nmcli/features/gsm.feature
@@ -126,3 +126,21 @@ Feature: nmcli: gsm
     * Bring "up" connection "gsm"
     Then "full" is visible with command "nmcli g" in "60" seconds
      And Ping "nix.cz" "7" times
+
+
+    @gsm @mmcli @eth0
+    @gsm_mmcli_list_modems
+    Scenario: mmcli - gsm - list connected modems
+      # The modem is connected to the test system in advance.
+      Then "Found 1 modem" is visible with command "mmcli -L" in "30" seconds
+      Then "/org/freedesktop/ModemManager" is visible with command "mmcli -L"
+
+
+    @gsm @mmcli @eth0
+    @gsm_mmcli_log_level
+    Scenario: mmcli - gsm increase log level to DEBUG
+      # An important function of ModemManager when troubleshooting modems and connectivity issues.
+      * Execute "mmcli -G INFO"
+      * Execute "mmcli -G DEBUG"
+      Then "logging: level 'DEBUG'" is visible with command "journalctl | tail | grep ModemManager" in "10" seconds
+      * Execute "mmcli -G INFO"

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -608,6 +608,8 @@ gsm_load_from_file, ., nmcli/./runtest.sh gsm_load_from_file ,,60m
 gsm_create_assisted_connection, ., nmcli/./runtest.sh gsm_create_assisted_connection ,,60m
 #gsm_up_down_up, ., nmcli/./runtest.sh gsm_up_down_up ,,60m
 #gsm_up_up, ., nmcli/./runtest.sh gsm_up_up ,,60m
+gsm_mmcli_list_modems, ., nmcli/./runtest.sh gsm_mmcli_list_modems ,,60m
+gsm_mmcli_log_level, ., nmcli/./runtest.sh gsm_mmcli_log_level ,,60m
 #@gsm_end
 
 #@wifi_hwsim_start


### PR DESCRIPTION
Implement tests for two useful functions of ModemManager:
1. List available modems via mmcli
2. Increase verbosity level to DEBUG in the system journal