### PR TITLE
ipv4: disable renewal_gw_after_dhcp_outage_for_assumed_var1 on 1.10

### DIFF
--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1206,6 +1206,7 @@ Feature: nmcli: ipv4
 
 
     @rhbz1265239
+    @ver-=1.10.0
     @teardown_testveth @long
     @renewal_gw_after_dhcp_outage_for_assumed_var1
     Scenario: NM - ipv4 - assumed address renewal after DHCP outage for in-memory assumed
@@ -1224,6 +1225,27 @@ Feature: nmcli: ipv4
     Then "routers = 192.168.99.1" is visible with command "nmcli con show testX" in "400" seconds
     Then "default" is visible with command "ip r| grep testX" in "150" seconds
     When "inet 192.168.99" is visible with command "ip a s testX" in "10" seconds
+
+
+    @rhbz1265239
+    @ver+=1.10.1
+    @teardown_testveth @long
+    @renewal_gw_after_dhcp_outage_for_assumed_var1
+    Scenario: NM - ipv4 - assumed address renewal after DHCP outage for in-memory assumed
+    * Prepare simulated test "testX" device
+    * Add connection type "ethernet" named "ethie" for device "testX"
+    * Bring "up" connection "ethie"
+    When "default" is visible with command "ip r |grep testX" in "30" seconds
+    When "inet 192" is visible with command "ip a s |grep testX" in "30" seconds
+    * Execute "ip netns exec testX_ns kill -SIGSTOP $(cat /tmp/testX_ns.pid)"
+    * Execute "systemctl stop NetworkManager"
+    * Execute "sudo rm -rf /etc/sysconfig/network-scripts/ifcfg-ethie"
+    * Execute "systemctl start NetworkManager"
+    When "default" is not visible with command "ip r |grep testX" in "130" seconds
+    When "inet 192.168.99" is not visible with command "ip a s testX" in "10" seconds
+    * Execute "ip netns exec testX_ns kill -SIGCONT $(cat /tmp/testX_ns.pid)"
+    Then "default" is not visible with command "ip r| grep testX" in "150" seconds
+    Then "inet 192.168.99" is not visible with command "ip a s testX" in "10" seconds
 
 
     @rhbz1205405

--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1244,7 +1244,7 @@ Feature: nmcli: ipv4
     When "default" is not visible with command "ip r |grep testX" in "130" seconds
     When "inet 192.168.99" is not visible with command "ip a s testX" in "10" seconds
     * Execute "ip netns exec testX_ns kill -SIGCONT $(cat /tmp/testX_ns.pid)"
-    Then "default" is not visible with command "ip r| grep testX" for full "150" seconds
+    Then "default" is not visible with command "ip r| grep testX" in "150" seconds
     Then "inet 192.168.99" is not visible with command "ip a s testX" in "10" seconds
 
 

--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1244,7 +1244,7 @@ Feature: nmcli: ipv4
     When "default" is not visible with command "ip r |grep testX" in "130" seconds
     When "inet 192.168.99" is not visible with command "ip a s testX" in "10" seconds
     * Execute "ip netns exec testX_ns kill -SIGCONT $(cat /tmp/testX_ns.pid)"
-    Then "default" is not visible with command "ip r| grep testX" in "150" seconds
+    Then "default" is not visible with command "ip r| grep testX" for full "150" seconds
     Then "inet 192.168.99" is not visible with command "ip a s testX" in "10" seconds
 
 


### PR DESCRIPTION
The purpose of the test is to check that NM keeps renewing the lease
for an external DHCP connection. NM used to do that in the past
because it could happen that after a NM restart the connection
matching didn't work and thus the on-disk connection was not
assumed. In such situation, it was considered better to continue doing
DHCP rather than losing connectivity.

Now NM doesn't do connection matching on daemon restart but uses a
state file to know exactly which connection was active. Therefore
there is no risk that a DHCP connection becomes external. If a
connection is external, we should not touch it anymore.

The test should be skipped from NM 1.10.

https://bugzilla.redhat.com/show_bug.cgi?id=1518091