### PR TITLE
bond device rename

### DIFF
--- a/nmcli/features/bond.feature
+++ b/nmcli/features/bond.feature
@@ -1336,7 +1336,7 @@
 
 
     @ver+=1.8.1
-    @rhbz979425
+    @rhbz979425 @rhbz1450219
     @slaves @bond
     @bond_device_rename
     Scenario: NM - bond - device rename

--- a/nmcli/features/bond.feature
+++ b/nmcli/features/bond.feature
@@ -1291,6 +1291,7 @@
       And "666" is visible with command "cat /sys/class/net/nm-bond/bonding/lp_interval"
 
 
+    @ver-=1.8.0
     @rhbz979425
     @slaves @bond
     @bond_device_rename
@@ -1301,6 +1302,48 @@
      * Bring "down" connection "bond0"
      # VVV Workaround for rhbz1450219
      * Wait for at least "2" seconds
+     * Open editor for connection "bond0"
+     * Set a property named "connection.interface-name" to "nm-bond" in editor
+     * Save in editor
+     Then Value saved message showed in editor
+     * Quit editor
+     * Bring "up" connection "bond0"
+     * Bring "up" connection "bond0.0"
+     * Bring "up" connection "bond0.1"
+     Then Check bond "nm-bond" link state is "up"
+
+
+    @ver-=1.8.1
+    @rhbz979425
+    @slaves @bond
+    @bond_device_rename
+    Scenario: NM - bond - device rename
+     * Add connection type "bond" named "bond0" for device "bondy"
+     * Add slave connection for master "nm-bond" on device "eth1" named "bond0.0"
+     * Add slave connection for master "nm-bond" on device "eth2" named "bond0.1"
+     * Bring "down" connection "bond0"
+     # VVV Workaround for rhbz1450219
+     * Wait for at least "2" seconds
+     * Open editor for connection "bond0"
+     * Set a property named "connection.interface-name" to "nm-bond" in editor
+     * Save in editor
+     Then Value saved message showed in editor
+     * Quit editor
+     * Bring "up" connection "bond0"
+     * Bring "up" connection "bond0.0"
+     * Bring "up" connection "bond0.1"
+     Then Check bond "nm-bond" link state is "up"
+
+
+    @ver+=1.8.1
+    @rhbz979425
+    @slaves @bond
+    @bond_device_rename
+    Scenario: NM - bond - device rename
+     * Add connection type "bond" named "bond0" for device "bondy"
+     * Add slave connection for master "nm-bond" on device "eth1" named "bond0.0"
+     * Add slave connection for master "nm-bond" on device "eth2" named "bond0.1"
+     * Bring "down" connection "bond0"
      * Open editor for connection "bond0"
      * Set a property named "connection.interface-name" to "nm-bond" in editor
      * Save in editor


### PR DESCRIPTION
introduce new 1.8.1+ version with removed workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1450219