### PR TITLE
renewal_gw_after_dhcp_outage_for_assumed_var1 slight modification

### DIFF
--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1244,7 +1244,7 @@ Feature: nmcli: ipv4
     When "default" is not visible with command "ip r |grep testX" in "130" seconds
     When "inet 192.168.99" is not visible with command "ip a s testX" in "10" seconds
     * Execute "ip netns exec testX_ns kill -SIGCONT $(cat /tmp/testX_ns.pid)"
-    Then "default" is not visible with command "ip r| grep testX" in "150" seconds
+    Then "default" is not visible with command "ip r| grep testX" for full "150" seconds
     Then "inet 192.168.99" is not visible with command "ip a s testX" in "10" seconds
 
 

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -1168,6 +1168,21 @@ def check_pattern_visible_with_command_fortime(context, pattern, command, second
         sleep(1)
 
 
+@step(u'"{pattern}" is not visible with command "{command}" for full "{seconds}" seconds')
+def check_pattern_visible_with_command_fortime(context, pattern, command, seconds):
+    cmd = '/bin/bash -c "%s"' %command
+    seconds = int(seconds)
+    orig_seconds = seconds
+    while seconds > 0:
+        ifconfig = pexpect.spawn(cmd, timeout = 180, logfile=context.log)
+        if ifconfig.expect([pattern, pexpect.EOF]) != 0:
+            pass
+        else:
+            raise Exception('Pattern %s appeared in %d seconds' % (pattern, orig_seconds-seconds))
+        seconds = seconds - 1
+        sleep(1)
+
+
 @step(u'"{pattern}" is not visible with command "{command}" in "{seconds}" seconds')
 def check_pattern_not_visible_with_command_in_time(context, pattern, command, seconds):
     cmd = '/bin/bash -c "%s"' %command


### PR DESCRIPTION
We need to check for full 150 seconds that default doesn't reappear
not just that it isn't present once.