### PR TITLE
vlan: add 'vlan_mtu_from_parent_with_slow_dhcp' test

### DIFF
--- a/testmapper.txt
+++ b/testmapper.txt
@@ -336,6 +336,7 @@ reorder_hdr, ., nmcli/./runtest.sh reorder_hdr ,
 vlan_preserve_assumed_connection_ips, ., nmcli/./runtest.sh vlan_preserve_assumed_connection_ips ,
 vlan_create_many_vlans, ., nmcli/./runtest.sh vlan_create_many_vlans ,
 vlan_mtu_from_parent, ., nmcli/./runtest.sh vlan_mtu_from_parent ,
+vlan_mtu_from_parent_with_slow_dhcp, ., nmcli/./runtest.sh vlan_mtu_from_parent_with_slow_dhcp ,
 default_route_for_vlan_over_team, ., nmcli/./runtest.sh default_route_for_vlan_over_team ,
 #@vlan_end
 


### PR DESCRIPTION
Check that NM correctly recheck parent's MTU when slow DHCP is in
place. Present since 1.10.

https://bugzilla.redhat.com/show_bug.cgi?id=1414901