### PR TITLE
gen: add managed state rollback test

### DIFF
--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1291,6 +1291,19 @@ Feature: nmcli - general
     Then "unmanaged" is visible with command "nmcli device show eth1" in "5" seconds
 
 
+    @rhbz1464904
+    @ver+=1.10.0
+    @manage_eth1
+    @snapshot_rollback_managed
+    Scenario: NM - general - snapshot and rollback managed
+    * Execute "nmcli device set eth1 managed on"
+    * Snapshot "create" for "eth1" with timeout "10"
+    * Execute "nmcli device set eth1 managed off"
+    When "unmanaged" is visible with command "nmcli device show eth1" in "5" seconds
+    * Wait for at least "15" seconds
+    Then "unmanaged" is not visible with command "nmcli device show eth1" in "5" seconds
+
+
     @rhbz1369716
     @ver+=1.8.0
     @bond @slaves

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -472,6 +472,7 @@ snapshot_rollback, ., nmcli/./runtest.sh snapshot_rollback ,
 snapshot_rollback_all_devices, ., nmcli/./runtest.sh snapshot_rollback_all_devices ,
 snapshot_rollback_all_devices_with_timeout, ., nmcli/./runtest.sh snapshot_rollback_all_devices_with_timeout ,
 snapshot_rollback_unmanaged, ., nmcli/./runtest.sh snapshot_rollback_unmanaged ,
+snapshot_rollback_managed, ., nmcli/./runtest.sh snapshot_rollback_managed ,
 snapshot_rollback_soft_device, ., nmcli/./runtest.sh snapshot_rollback_soft_device ,
 stable_mem_consumption, ., nmcli/./runtest.sh stable_mem_consumption ,,20m
 dummy_connection, ., nmcli/./runtest.sh dummy_connection ,


### PR DESCRIPTION
NM is now able to rollback not only managed state but unmanaged as
well.

https://bugzilla.redhat.com/show_bug.cgi?id=1464904