### PR TITLE
runonce: make a test more robust for slow devices

### DIFF
--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -908,6 +908,7 @@ Feature: nmcli - general
 
 
     @rhbz1201497
+    @ver-=1.9.9
     @runonce @restore_hostname @eth0
     @run_once_helper_for_localhost_localdomain
     Scenario: NM - general - helper running for localhost on localdo
@@ -920,11 +921,35 @@ Feature: nmcli - general
     * Execute "echo '[main]' > /etc/NetworkManager/conf.d/01-run-once.conf"
     * Execute "echo 'configure-and-quit=yes' >> /etc/NetworkManager/conf.d/01-run-once.conf"
     * Execute "echo 'dhcp=internal' >> /etc/NetworkManager/conf.d/01-run-once.conf"
+    * Execute "ip link set dev eth0 up"
     * Execute "sleep 1"
     * Start NM
     Then "eth0" is visible with command "ps aux|grep helper" in "40" seconds
     Then "eth0" is visible with command "ps aux|grep helper" for full "20" seconds
 
+
+    @rhbz1201497
+    @ver+=1.10
+    @runonce @restore_hostname @eth0
+    @run_once_helper_for_localhost_localdomain
+    Scenario: NM - general - helper running for localhost on localdo
+    * Bring "up" connection "testeth0"
+    * Disconnect device "eth0"
+    * Execute "sleep 2"
+    * Stop NM and clean "eth0"
+    When "state DOWN" is visible with command "ip a s eth0" in "5" seconds
+    * Execute "hostnamectl set-hostname localhost.localdomain"
+    * Execute "echo '[main]' > /etc/NetworkManager/conf.d/01-run-once.conf"
+    * Execute "echo 'configure-and-quit=yes' >> /etc/NetworkManager/conf.d/01-run-once.conf"
+    * Execute "echo 'dhcp=internal' >> /etc/NetworkManager/conf.d/01-run-once.conf"
+    ## VVV Just to make sure slow devices will catch carrier
+    * Execute "echo '[device]' >> /etc/NetworkManager/conf.d/01-run-once.conf"
+    * Execute "echo 'match-device=interface-name:eth0' >> /etc/NetworkManager/conf.d/01-run-once.conf"
+    * Execute "echo 'carrier-wait-timeout=10000' >> /etc/NetworkManager/conf.d/01-run-once.conf"
+    * Execute "sleep 1"
+    * Start NM
+    Then "eth0" is visible with command "ps aux|grep helper" in "40" seconds
+    Then "eth0" is visible with command "ps aux|grep helper" for full "20" seconds
 
 
     @rhbz1086906

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -227,7 +227,6 @@ ipv6_preserve_cached_routes, ., nmcli/./runtest.sh ipv6_preserve_cached_routes ,
 #@ipv6_end
 
 #@ipv4_start
-run_once_helper_for_localhost_localdomain, ., nmcli/./runtest.sh  run_once_helper_for_localhost_localdomain ,
 nmcli_general_correct_profile_activated_after_restart, ., nmcli/./runtest.sh nmcli_general_correct_profile_activated_after_restart ,
 nmcli_general_profile_pickup_doesnt_break_network, ., nmcli/./runtest.sh nmcli_general_profile_pickup_doesnt_break_network ,
 ipv4_take_manually_created_ifcfg_with_ip, ., nmcli/./runtest.sh ipv4_take_manually_created_ifcfg_with_ip ,
@@ -422,6 +421,7 @@ nmcli_device_disconnect, ., nmcli/./runtest.sh nmcli_device_disconnect ,
 run_once_new_connection, ., nmcli/./runtest.sh run_once_new_connection ,
 run_once_ip4_renewal, ., nmcli/./runtest.sh run_once_ip4_renewal ,
 run_once_ip6_renewal, ., nmcli/./runtest.sh run_once_ip6_renewal ,
+run_once_helper_for_localhost_localdomain, ., nmcli/./runtest.sh  run_once_helper_for_localhost_localdomain ,
 wait-online-for-both-ips, ., nmcli/./runtest.sh wait-online-for-both-ips ,
 wait_online_with_autoconnect_no_connection, ., nmcli/./runtest.sh wait_online_with_autoconnect_no_connection ,
 policy_based_routing, ., nmcli/./runtest.sh policy_based_routing ,


### PR DESCRIPTION
Two versions introduced now. Pre 1.8 with ip link up eth0 to up
device slightly earlier to give NM more time and 1.10+ using NM's
new wait-for-carrier=10000 option.