### PR TITLE
team: config_invalid3: skip test for nm version > nm-1-10-0

### DIFF
--- a/nmcli/features/team.feature
+++ b/nmcli/features/team.feature
@@ -493,6 +493,7 @@
 
      @rhbz1312726
      @ver+=1.4.0
+     @ver-=1.10.0
      @team_slaves @team @clean @long
      @config_invalid3
      Scenario: nmcli - team - config - set invalid mode


### PR DESCRIPTION
Now the team configuration is checked upon set: in particular, if the
runner selected is unknown, the connection change is dropped.

The config_invalid3 test would fail because the config change with the invalid runner is now early rejected and then the connection can be activated successful . The only invalid team config is the one with an invalid runner. 