### PR TITLE
nmtui: skip error check when invalid route present for 1.8

### DIFF
--- a/nmtui/features/ipv4.feature
+++ b/nmtui/features/ipv4.feature
@@ -337,8 +337,29 @@ Feature: IPv4 TUI tests
     Then Cannot add ip route "192.168.1.10/24 123456789"
 
 
-    @veth
-    @ipv4
+    @veth @ipv4
+    @ver-=1.9.0
+    @nmtui_ipv4_routes_set_unreachable_route
+    Scenario: nmtui - ipv4 - routes - set unreachable route
+    * Prepare new connection of type "Ethernet" named "ethernet"
+    * Set "Device" field to "eth1"
+    * Set "IPv4 CONFIGURATION" category to "Manual"
+    * Come in "IPv4 CONFIGURATION" category
+    * In "Addresses" property add "192.168.122.2/24"
+    * Set "Gateway" field to "192.168.122.1"
+    * Add ip route "192.168.1.0/24 192.168.3.11 1"
+    * Set "IPv6 CONFIGURATION" category to "Ignore"
+    * Ensure "Automatically connect" is not checked
+    * Confirm the connection settings
+    * Come back to main screen
+    * Choose to "Activate a connection" from main screen
+    * Select connection "ethernet" in the list
+    * Choose to "<Activate>" a connection
+    When "eth1\s+ethernet\s+disconnected" is visible with command "nmcli device" in "5" seconds
+
+
+    @veth @ipv4
+    @ver+=1.9.1
     @nmtui_ipv4_routes_set_unreachable_route
     Scenario: nmtui - ipv4 - routes - set unreachable route
     * Prepare new connection of type "Ethernet" named "ethernet"


### PR DESCRIPTION
This error is unstable in 1.8 branch. We have multiversion test now