### PR TITLE
team: fix describe to pass new team object

### DIFF
--- a/nmcli/features/team.feature
+++ b/nmcli/features/team.feature
@@ -638,7 +638,7 @@
      * Open editor for a type "team"
      Then Check "<<< team >>>|=== \[config\] ===|\[NM property description\]" are present in describe output for object "team"
      Then Check "The JSON configuration for the team network interface.  The property should contain raw JSON configuration data suitable for teamd, because the value is passed directly to teamd. If not specified, the default configuration is used.  See man teamd.conf for the format details." are present in describe output for object "team.config"
-      * Submit "g t" in editor
+      * Submit "g team" in editor
      Then Check "NM property description|The JSON configuration for the team network interface.  The property should contain raw JSON configuration data suitable for teamd, because the value is passed directly to teamd. If not specified, the default configuration is used.  See man teamd.conf for the format details." are present in describe output for object "config"
       * Submit "g c" in editor
      Then Check "The JSON configuration for the team network interface.  The property should contain raw JSON configuration data suitable for teamd, because the value is passed directly to teamd. If not specified, the default configuration is used.  See man teamd.conf for the format details." are present in describe output for object " "


### PR DESCRIPTION
New items in team object can be filled instead of using json config.
Describe now reflects that.