### PR TITLE
add: persistent_ipv6_after_device_rename

### DIFF
--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -1562,6 +1562,8 @@ def after_scenario(context, scenario):
             call('udevadm control --reload-rules', shell=True)
             call('udevadm settle', shell=True)
             sleep(1)
+            call('systemctl restart NetworkManager', shell=True)
+
 
         if '@restore_rp_filters' in scenario.tags:
             print ("---------------------------")

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -1551,6 +1551,11 @@ def delete_device(context, device):
     elif r == 1:
         raise Exception('nmcli device delete %s timed out (180s)' % device)
 
+@step(u'Rename device "{old_device}" to "{new_device}"')
+def delete_device(context, old_device, new_device):
+    command_code(context, "ip link set dev %s down" % old_device)
+    command_code(context, "ip link set %s name %s" % (old_device, new_device))
+    command_code(context, "ip link set dev %s ip" % old_device)
 
 @step(u'Restart NM')
 def restart_NM(context):

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -226,6 +226,7 @@ ipv6_keep_external_routes, ., nmcli/./runtest.sh ipv6_keep_external_routes ,
 nmcli_general_finish_dad_without_carrier, ., nmcli/./runtest.sh nmcli_general_finish_dad_without_carrier ,
 ipv4_dad_not_preventing_ipv6, ., nmcli/./runtest.sh ipv4_dad_not_preventing_ipv6 ,
 ipv6_preserve_cached_routes, ., nmcli/./runtest.sh ipv6_preserve_cached_routes ,
+persistent_ipv6_after_device_rename, ., nmcli/./runtest.sh persistent_ipv6_after_device_rename ,
 #@ipv6_end
 
 #@ipv4_start


### PR DESCRIPTION
Check that NM doesn't turn off ipv6 when overtaking renamed device.

https://bugzilla.redhat.com/show_bug.cgi?id=1368018