### PR TITLE
bridge: add bridge_autoconnect_slaves_when_master_reconnected test

### DIFF
--- a/nmcli/features/bridge.feature
+++ b/nmcli/features/bridge.feature
@@ -183,6 +183,7 @@ Feature: nmcli - bridge
     * Add a new connection of type "bridge-slave" and options "autoconnect no ifname eth1.80 master br15"
     Then "BRIDGE=br15" is visible with command "cat /etc/sysconfig/network-scripts/ifcfg-bridge-slave-eth1.80"
 
+
 	@bridge
     @bridge_remove_slave
     Scenario: nmcli - bridge - remove slave
@@ -240,6 +241,29 @@ Feature: nmcli - bridge
     * Bring up connection "br10"
     Then  "br10.*eth1" is visible with command "brctl show"
     Then Disconnect device "br10"
+
+
+    @rhbz1437598
+    @ver+=1.10.0
+    @bridge
+    @bridge_autoconnect_slaves_when_master_reconnected
+    Scenario: nmcli - bridge - start slave upon master reconnection
+    * Add a new connection of type "bridge" and options "con-name br10 ifname br10"
+    * Add a new connection of type "bridge-slave" and options "con-name br10-slave ifname eth2 master br10"
+    * Open editor for connection "br10"
+    * Set a property named "ipv4.method" to "manual" in editor
+    * Set a property named "ipv4.addresses" to "192.168.1.19/24" in editor
+    * Save in editor
+    * Quit editor
+    * Bring "up" connection "br10"
+    When "(connected)" is visible with command "nmcli device show br10" in "10" seconds
+    * Disconnect device "br10"
+    When "disconnected" is visible with command "nmcli device show eth2" in "5" seconds
+     And "(connected)" is not visible with command "nmcli device show br10" in "5" seconds
+    * Bring up connection "br10"
+    Then  "br10.*eth2" is visible with command "brctl show" in "10" seconds
+     And "(connected)" is visible with command "nmcli device show eth2" in "5" seconds
+     And "(connected)" is visible with command "nmcli device show br10" in "5" seconds
 
 
     @bridge

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -93,7 +93,8 @@ bridge_add_slave, ., nmcli/./runtest.sh bridge_add_slave, bridge-utils
 bridge_remove_slave, ., nmcli/./runtest.sh bridge_remove_slave, bridge-utils
 bridge_up_with_slaves, ., nmcli/./runtest.sh bridge_up_with_slaves, bridge-utils
 bridge_up_slave, ., nmcli/./runtest.sh bridge_up_slave, bridge-utils
-bridge_slaves_start_via_master, ., nmcli/./runtest.sh  bridge_slaves_start_via_master ,
+bridge_slaves_start_via_master, ., nmcli/./runtest.sh bridge_slaves_start_via_master ,
+bridge_autoconnect_slaves_when_master_reconnected, ., nmcli/./runtest.sh bridge_autoconnect_slaves_when_master_reconnected ,
 bridge_dhcp_config_with_ethernet_port, ., nmcli/./runtest.sh bridge_dhcp_config_with_ethernet_port, bridge-utils
 bridge_dhcp_config_with_multiple_ethernet_ports, ., nmcli/./runtest.sh bridge_dhcp_config_with_multiple_ethernet_ports, bridge-utils
 bridge_static_config_with_multiple_ethernet_ports, ., nmcli/./runtest.sh bridge_static_config_with_multiple_ethernet_ports, bridge-utils


### PR DESCRIPTION
Check that bridge slave cna be autoconnected when it wasn't explicitely
disconnected before. This allows to restart bridge with new settings via
restarting master only. Slaves will be autoconnected.

https://bugzilla.redhat.com/show_bug.cgi?id=1437598