### PR TITLE
ipv4: add 'ipv4_route_onsite' test

### DIFF
--- a/testmapper.txt
+++ b/testmapper.txt
@@ -318,6 +318,7 @@ ipv4_rp_filter_do_not_touch, ., nmcli/./runtest.sh ipv4_rp_filter_do_not_touch ,
 ipv4_rp_filter_reset, ., nmcli/./runtest.sh ipv4_rp_filter_reset ,
 ipv4_dhcp_do_not_add_route_to_server, ., nmcli/./runtest.sh ipv4_dhcp_do_not_add_route_to_server ,
 ipv4_keep_external_addresses, ., nmcli/./runtest.sh ipv4_keep_external_addresses ,
+ipv4_route_onsite, ., nmcli/./runtest.sh ipv4_route_onsite ,
 #@ipv4_end
 
 #@vlan_start


### PR DESCRIPTION
If onsite is specified there is a device route added which allows
to route to networks that are not directly accessible.

https://bugzilla.redhat.com/show_bug.cgi?id=1428334