### PR TITLE
general: reactivate dummy device with qdisc

### DIFF
--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1443,6 +1443,20 @@ Feature: nmcli - general
     Then "1.2.3.4/24" is visible with command "ip a s BBB | grep inet"
 
 
+    @rhbz1527197
+    @ver+=1.10.1
+    @BBB
+    @dummy_with_qdisc
+    Scenario: NM - general - create dummy with qdisc
+    * Add a new connection of type "dummy" and options "ifname BBB con-name BBB ipv4.method link-local ipv6.method link-local"
+    * Bring up connection "BBB"
+    * Bring up connection "BBB"
+    * Bring up connection "BBB"
+    * Execute "tc qdisc add dev BBB root handle 1234 fq_codel"
+    * Bring up connection "BBB"
+    Then "dummy" is visible with command "ip -d l show BBB | grep dummy"
+
+
     @rhbz1337997
     @ver+=1.6.0
     @macsec @not_on_aarch64_but_pegas

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -492,6 +492,7 @@ snapshot_rollback_soft_device, ., nmcli/./runtest.sh snapshot_rollback_soft_devi
 stable_mem_consumption, ., nmcli/./runtest.sh stable_mem_consumption ,,20m
 stable_mem_consumption2, ., nmcli/./runtest.sh stable_mem_consumption2 ,,20m
 dummy_connection, ., nmcli/./runtest.sh dummy_connection ,
+dummy_with_qdisc, ., nmcli/./runtest.sh dummy_with_qdisc ,
 macsec_psk, ., nmcli/./runtest.sh macsec_psk ,
 non_utf_device, ., nmcli/./runtest.sh non_utf_device ,
 connectivity_check, ., nmcli/./runtest.sh connectivity_check ,


### PR DESCRIPTION
Make sure that qdisc is removed despite kernel return code. This
blocks re-activation otherwise.

https://bugzilla.redhat.com/show_bug.cgi?id=1527197

@Build:nm-1-10