### PR TITLE
Devel/vb/team abstraction

### DIFF
--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -365,6 +365,12 @@ def check_same_noted_values(context, i1, i2):
      "Noted values: %s != %s !" % (context.noted[i1].strip(), context.noted[i2].strip())
 
 
+@step(u'Check noted values "{i1}" and "{i2}" are not the same')
+def check_same_noted_values(context, i1, i2):
+    assert context.noted[i1].strip() != context.noted[i2].strip(), \
+     "Noted values: %s == %s !" % (context.noted[i1].strip(), context.noted[i2].strip())
+
+
 @step(u'Check noted output contains "{pattern}"')
 def check_noted_output_contains(context, pattern):
     assert re.search(pattern, context.noted_value) is not None, "Noted output does not contain the pattern %s" % pattern

--- a/nmcli/features/team.feature
+++ b/nmcli/features/team.feature
@@ -841,19 +841,24 @@
      And Check slave "eth1" in team "nm-team" is "up"
     * Execute "nmcli connection modify team0 team.runner broadcast"
     * Bring "up" connection "team0"
-    Then "\"kernel_team_mode_name\": \"broadcast\"" is visible with command "sudo teamdctl nm-team state dump"
+    Then "{\"runner\": {\"name\": \"broadcast\"}}" is visible with command "nmcli connection show team0 |grep 'team.config'"
+     And "\"kernel_team_mode_name\": \"broadcast\"" is visible with command "sudo teamdctl nm-team state dump"
      And Check slave "eth1" in team "nm-team" is "up"
     * Execute "nmcli connection modify team0 team.runner activebackup"
     * Bring "up" connection "team0"
     Then "\"kernel_team_mode_name\": \"activebackup\"" is visible with command "sudo teamdctl nm-team state dump"
+     And "{\"runner\": {\"name\": \"activebackup\"}}" is visible with command "nmcli connection show team0 |grep 'team.config'"
      And Check slave "eth1" in team "nm-team" is "up"
     * Execute "nmcli connection modify team0 team.runner loadbalance"
     * Bring "up" connection "team0"
     Then "\"kernel_team_mode_name\": \"loadbalance\"" is visible with command "sudo teamdctl nm-team state dump"
+    # And "{\"runner\": {\"name\": \"loadbalance\", \"tx_hash\": [\"eth\", \"ipv4\", \"ipv6\"]}}"
+     And "{\"runner\": {\"name\": \"loadbalance\", \"tx_hash\": \[\"eth\", \"ipv4\", \"ipv6\"\]}}" is visible with command "nmcli connection show team0 |grep 'team.config'"
      And Check slave "eth1" in team "nm-team" is "up"
     * Execute "nmcli connection modify team0 team.runner lacp"
     * Bring "up" connection "team0"
     Then "\"kernel_team_mode_name\": \"loadbalance\"" is visible with command "sudo teamdctl nm-team state dump"
+     And "{\"runner\": {\"name\": \"lacp\", \"tx_hash\": \[\"eth\", \"ipv4\", \"ipv6\"\]}}" is visible with command "nmcli connection show team0 |grep 'team.config'"
 
 
     @rhbz1398925
@@ -876,6 +881,7 @@
     Then Check noted values "team" and "team1" are the same
      And Check noted values "team" and "eth1" are the same
      And Check noted values "team" and "team2" are not the same
+     And "by_active" is visible with command "nmcli connection show team0 |grep 'team.runner-hwaddr-policy'"
     * Bring "down" connection "team0"
     * Execute "nmcli connection modify team0 team.runner activebackup team.runner-hwaddr-policy only_active"
     * Bring "up" connection "team0"
@@ -888,6 +894,7 @@
     * Bring "down" connection "team0.0"
     * Note the output of "ip a s eth2|grep ether |awk '{print $2}'" as value "team2"
     Then Check noted values "team" and "team2" are the same
+     And "only_active" is visible with command "nmcli connection show team0 |grep 'team.runner-hwaddr-policy'"
     * Bring "down" connection "team0"
     * Execute "nmcli connection modify team0 team.runner activebackup team.runner-hwaddr-policy same_all"
     * Bring "up" connection "team0"
@@ -913,9 +920,11 @@
     * Add slave connection for master "nm-team" on device "eth1" named "team0.0"
     * Bring "up" connection "team0"
     When "\"tx_hash\": \[\s+\"eth\",\s+\"ipv4\",\s+\"ipv6\"\s+\]" is visible with command "teamdctl nm-team conf dump"
+     And "{\"runner\": {\"name\": \"lacp\", \"tx_hash\": \[\"eth\", \"ipv4\", \"ipv6\"\]}}" is visible with command "nmcli connection show team0 |grep 'team.config'"
     * Execute "nmcli connection modify team0 team.runner-tx-hash l3"
     * Bring "up" connection "team0"
     Then "\"tx_hash\": \[\s+\"l3\"\s+\]" is visible with command "teamdctl nm-team conf dump"
+     And "{\"runner\": {\"name\": \"lacp\", \"tx_hash\": \[\"l3\"\]}}" is visible with command "nmcli connection show team0 |grep 'team.config'"
 
 
     @rhbz1398925
@@ -930,6 +939,7 @@
     * Execute "nmcli connection modify team0 team.runner-tx-balancer basic"
     * Bring "up" connection "team0"
     Then "\"name\": \"basic\"" is visible with command "teamdctl nm-team conf dump"
+     And "\"tx_balancer\": {\"name\": \"basic\"}" is visible with command "nmcli connection show team0 |grep 'team.config'"
 
 
     @rhbz1398925
@@ -944,6 +954,7 @@
     * Execute "nmcli connection modify team0 team.runner-tx-balancer-interval 100"
     * Bring "up" connection "team0"
     Then "\"balancing_interval\": 100" is visible with command "teamdctl nm-team conf dump"
+     And "\"tx_balancer\": {\"balancing_interval\": 100}" is visible with command "nmcli connection show team0 |grep 'team.config'"
 
 
     @rhbz1398925
@@ -958,6 +969,7 @@
     * Execute "nmcli connection modify team0 team.runner-active no"
     * Bring "up" connection "team0"
     Then "\"active\": false" is visible with command "sudo teamdctl nm-team state dump"
+     And "\"active\": false" is visible with command "nmcli connection show team0 |grep 'team.config'"
 
 
     @rhbz1398925
@@ -969,6 +981,8 @@
     * Add slave connection for master "nm-team" on device "eth1" named "team0.0"
     * Bring "up" connection "team0"
     When "\"fast_rate\": true" is visible with command "sudo teamdctl nm-team state dump"
+     And "\"fast_rate\": true" is visible with command "nmcli connection show team0 |grep 'team.config'"
     * Execute "nmcli connection modify team0 team.runner-fast-rate no"
     * Bring "up" connection "team0"
     Then "\"fast_rate\": false" is visible with command "sudo teamdctl nm-team state dump"
+     And "\"fast_rate\": true" is not visible with command "nmcli connection show team0 |grep 'team.config'"

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -173,6 +173,9 @@ team_abs_set_runner_min_ports, ., nmcli/./runtest.sh team_abs_set_runner_min_por
 team_abs_set_runner_agg_select_policy, ., nmcli/./runtest.sh team_abs_set_runner_agg_select_policy ,
 team_abs_set_notify_peers, ., nmcli/./runtest.sh team_abs_set_notify_peers ,
 team_abs_set_mcast_rejoin, ., nmcli/./runtest.sh team_abs_set_mcast_rejoin ,
+team_abs_set_link_watchers_ethtool, ., nmcli/./runtest.sh team_abs_set_link_watchers_ethtool ,
+team_abs_set_link_watchers_nsna_ping, ., nmcli/./runtest.sh team_abs_set_link_watchers_nsna_ping ,
+team_abs_set_link_watchers_arp_ping, ., nmcli/./runtest.sh team_abs_set_link_watchers_arp_ping ,
 #@team_end
 
 #@ipv6_start

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -168,6 +168,11 @@ team_abs_set_runner_tx_balancer, ., nmcli/./runtest.sh team_abs_set_runner_tx_ba
 team_abs_set_runner_tx_balancer_interval, ., nmcli/./runtest.sh team_abs_set_runner_tx_balancer_interval ,
 team_abs_set_runner_active, ., nmcli/./runtest.sh team_abs_set_runner_active ,
 team_abs_set_runner_fast_rate, ., nmcli/./runtest.sh team_abs_set_runner_fast_rate ,
+team_abs_set_runner_sys_prio, ., nmcli/./runtest.sh team_abs_set_runner_sys_prio ,
+team_abs_set_runner_min_ports, ., nmcli/./runtest.sh team_abs_set_runner_min_ports ,
+team_abs_set_runner_agg_select_policy, ., nmcli/./runtest.sh team_abs_set_runner_agg_select_policy ,
+team_abs_set_notify_peers, ., nmcli/./runtest.sh team_abs_set_notify_peers ,
+team_abs_set_mcast_rejoin, ., nmcli/./runtest.sh team_abs_set_mcast_rejoin ,
 #@team_end
 
 #@ipv6_start

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -161,6 +161,13 @@ vlan_in_team, ., nmcli/./runtest.sh vlan_in_team ,
 team_leave_L2_only_up_when_going_down, ., nmcli/./runtest.sh team_leave_L2_only_up_when_going_down ,
 team_add_into_firewall_zone, ., nmcli/./runtest.sh team_add_into_firewall_zone ,
 reconnect_back_to_ethernet_after_master_delete, ., nmcli/./runtest.sh reconnect_back_to_ethernet_after_master_delete ,
+team_abs_set_runners, ., nmcli/./runtest.sh team_abs_set_runners ,
+team_abs_set_runner_hwaddr_policy, ., nmcli/./runtest.sh team_abs_set_runner_hwaddr_policy ,
+team_abs_set_runner_tx_hash, ., nmcli/./runtest.sh team_abs_set_runner_tx_hash ,
+team_abs_set_runner_tx_balancer, ., nmcli/./runtest.sh team_abs_set_runner_tx_balancer ,
+team_abs_set_runner_tx_balancer_interval, ., nmcli/./runtest.sh team_abs_set_runner_tx_balancer_interval ,
+team_abs_set_runner_active, ., nmcli/./runtest.sh team_abs_set_runner_active ,
+team_abs_set_runner_fast_rate, ., nmcli/./runtest.sh team_abs_set_runner_fast_rate ,
 #@team_end
 
 #@ipv6_start


### PR DESCRIPTION
First set of test for team abstraction. It checks teamdctl values as well as team.config json configuration in NM.
https://bugzilla.redhat.com/show_bug.cgi?id=1398925
 * runners
 * hwadd policies
 * runner tx-hash
 * runner tx-balancer
 * runner tx-balancer-interval
 * lacp runner active
 * lacp runner fast-rate


@Build:nm-1-10