### PR TITLE
general: add 'do_not_touch_external_dummy' test

### DIFF
--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1473,6 +1473,21 @@ Feature: nmcli - general
     Then "dummy" is visible with command "ip -d l show BBB | grep dummy"
 
 
+    @rhbz1512316
+    @ver+=1.10.1
+    @BBB
+    @do_not_touch_external_dummy
+    Scenario: NM - general - do not touch external dummy device
+    Then Finish "sh tmp/repro_1512316.sh"
+     And Finish "sh tmp/repro_1512316.sh"
+     And Finish "sh tmp/repro_1512316.sh"
+     And Finish "sh tmp/repro_1512316.sh"
+     And Finish "sh tmp/repro_1512316.sh"
+     And Finish "sh tmp/repro_1512316.sh"
+     And Finish "sh tmp/repro_1512316.sh"
+     And Finish "sh tmp/repro_1512316.sh"
+
+
     @rhbz1337997
     @ver+=1.6.0
     @macsec @not_on_aarch64_but_pegas

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -510,6 +510,7 @@ stable_mem_consumption, ., nmcli/./runtest.sh stable_mem_consumption ,,20m
 stable_mem_consumption2, ., nmcli/./runtest.sh stable_mem_consumption2 ,,20m
 dummy_connection, ., nmcli/./runtest.sh dummy_connection ,
 dummy_with_qdisc, ., nmcli/./runtest.sh dummy_with_qdisc ,
+do_not_touch_external_dummy, ., nmcli/./runtest.sh do_not_touch_external_dummy ,
 macsec_psk, ., nmcli/./runtest.sh macsec_psk ,
 non_utf_device, ., nmcli/./runtest.sh non_utf_device ,
 connectivity_check, ., nmcli/./runtest.sh connectivity_check ,

--- a/tmp/repro_1512316.sh
+++ b/tmp/repro_1512316.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/bash
+
+DUMMY=BBB
+
+function set_up {
+    ip l add $DUMMY type dummy
+    ip l set up dev $DUMMY
+}
+
+function tear_down {
+    ip l del $DUMMY
+}
+
+function test_add_del_addr {
+    tear_down
+    set_up
+
+    ip a add 192.168.212.212/24 dev $DUMMY
+    ip a | grep -q '192.168.212.212/24' || { echo Error: missing ipv4 address after ipv4 add; exit 1; }
+
+    ip a add 2002:99::1/64 dev $DUMMY
+    ip a | grep -q '192.168.212.212/24' || { echo Error: missing ipv4 address after ipv6 add; exit 1; }
+    ip a | grep -q '2002:99' || { echo Error: missing ipv6 address after ipv6 add; exit 1; }
+
+    ip a del 2002:99::1/64 dev $DUMMY
+    ip a | grep -q '192.168.212.212/24' || { echo Error: missing ipv4 address after ipv6 del; exit 1; }
+    ip a | grep -q '2002:99' && { echo Error: found ipv6 address after ipv6 del; exit 1; }
+
+    ip a del 192.168.212.212/24 dev $DUMMY
+    ip a | grep -q '192.168.212.212/24' && { echo Error: found ipv4 address after ipv4 del; exit 1; }
+    ip a | grep -q '2002:99' && { echo Error: found ipv6 address after ipv4 del; exit 1; }
+}
+
+for i in `seq 1 100` :; do
+    test_add_del_addr
+done
+
+exit 0


### PR DESCRIPTION
Check that NM doesn't touch externally managed dummy device. Script
for adding removing ipv4 and ipv6 addresses is executed few hundred
times.

https://bugzilla.redhat.com/show_bug.cgi?id=1512316

@build:nm-1-10