### PR TITLE
team: add 'wait_for_slow_teamd' test

### DIFF
--- a/nmcli/features/team.feature
+++ b/nmcli/features/team.feature
@@ -1151,3 +1151,15 @@
     * Bring "up" connection "team0"
     Then "{\"link_watch\": {\"name\": \"arp_ping\", \"interval\": 100, \"missed_max\": 999, \"target_host\": \"1.2.3.1\", \"source_host\": \"1.2.3.4\"}}" is visible with command "nmcli connection show team0 |grep 'team.config'"
     And "\"link_watch\": {\s+\"interval\": 100,\s+\"missed_max\": 999,\s+\"name\": \"arp_ping\",\s+\"source_host\": \"1.2.3.4\",\s+\"target_host\": \"1.2.3.1\"" is visible with command "teamdctl nm-team conf dump"
+
+
+    @rhbz1415641
+    @ver+=1.10
+    @slow_team @team
+    @wait_for_slow_teamd
+    Scenario: nmcli - team - wait for slow team
+    * Add connection type "team" named "team0" for device "nm-team"
+    Then Bring "up" connection "team0"
+     And Bring "up" connection "team0"
+     And Bring "up" connection "team0"
+     And Bring "up" connection "team0"

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -176,6 +176,7 @@ team_abs_set_mcast_rejoin, ., nmcli/./runtest.sh team_abs_set_mcast_rejoin ,
 team_abs_set_link_watchers_ethtool, ., nmcli/./runtest.sh team_abs_set_link_watchers_ethtool ,
 team_abs_set_link_watchers_nsna_ping, ., nmcli/./runtest.sh team_abs_set_link_watchers_nsna_ping ,
 team_abs_set_link_watchers_arp_ping, ., nmcli/./runtest.sh team_abs_set_link_watchers_arp_ping ,
+wait_for_slow_teamd, ., nmcli/./runtest.sh wait_for_slow_teamd ,
 #@team_end
 
 #@ipv6_start


### PR DESCRIPTION
Sometimes when teamd is slower than usual 100ms wait time in NM is
not enough. This test requies special slowed teamd to properly
show the bug.

https://bugzilla.redhat.com/show_bug.cgi?id=1415641

@Build:nm-1-10