### PR TITLE
ipv6: add 'ipv6_multiple_default_routes' test

### DIFF
--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -1070,6 +1070,11 @@ def after_scenario(context, scenario):
             print ("deleting veth devices")
             call("sudo service dhcpd stop", shell=True)
 
+        if 'stop_radvd' in scenario.tags:
+            print ("---------------------------")
+            print ("deleting veth devices")
+            call("sudo systemctl stop radvd", shell=True)
+            call('rm -rf /etc/radvd.conf', shell=True)
         if 'mtu' in scenario.tags:
             print ("---------------------------")
             print ("deleting veth devices from mtu test")

--- a/nmcli/features/ipv6.feature
+++ b/nmcli/features/ipv6.feature
@@ -1316,3 +1316,17 @@ Feature: nmcli: ipv6
     * Execute "ethtool -A eth1 rx on tx on; ip addr flush eth1; ethtool -A eth1 rx off tx off; ip link set eth1 up"
     * Execute "ip addr add 192.168.100.2/24 dev eth1; ip addr add fe01::1/64 dev eth1"
     Then "fe01::1" is visible with command "ip a show dev eth1" in "5" seconds
+
+
+    @rhbz1445417
+    @ver+=1.10
+    @eth @stop_radvd @two_bridged_veths
+    @ipv6_multiple_default_routes
+    Scenario: NM - ipv6 - multiple default ipv6 routes
+    * Prepare veth pairs "test1" bridged over "vethbr"
+    * Execute "ip -6 addr add dead:beef::1/64 dev vethbr"
+    * Execute "ip -6 addr add beef:dead::1/64 dev test1p"
+    * Execute "ip -6 addr add fe80::dead:dead:dead:dead/64 dev test1p"
+    * Start radvd server with config from "tmp/radvd.conf"
+    * Add a new connection of type "ethernet" and options "con-name ethie ifname test1 ipv6.may-fail no"
+    Then "2" is visible with command "ip -6 r |grep test1 | grep default |wc -l" in "40" seconds

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -1322,6 +1322,14 @@ def prepare_veths(context, pairs_array, bridge):
         command_code(context, "ip link set dev %sp up" % pair)
 
 
+
+@step(u'Start radvd server with config from "{location}"')
+def start_radvd(context, location):
+    command_code(context, "rm -rf /etc/radvd.conf")
+    command_code(context, "cp %s /etc/radvd.conf" % location)
+    command_code(context, "systemctl restart radvd")
+    sleep(2)
+
 @step(u'Prepare simulated test "{device}" device with "{ipv4}" ipv4 and "{ipv6}" ipv6 dhcp address prefix and dhcp option "{option}"')
 @step(u'Prepare simulated test "{device}" device with "{ipv4}" ipv4 and "{ipv6}" ipv6 dhcp address prefix')
 @step(u'Prepare simulated test "{device}" device')

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -249,6 +249,7 @@ ipv4_dad_not_preventing_ipv6, ., nmcli/./runtest.sh ipv4_dad_not_preventing_ipv6
 ipv6_preserve_cached_routes, ., nmcli/./runtest.sh ipv6_preserve_cached_routes ,
 persistent_ipv6_after_device_rename, ., nmcli/./runtest.sh persistent_ipv6_after_device_rename ,
 add_ipv6_over_ipv4_configured_ext_device, ., nmcli/./runtest.sh add_ipv6_over_ipv4_configured_ext_device ,
+ipv6_multiple_default_routes, ., nmcli/./runtest.sh ipv6_multiple_default_routes ,
 #@ipv6_end
 
 #@ipv4_start

--- a/tmp/radvd.conf
+++ b/tmp/radvd.conf
@@ -1,0 +1,19 @@
+interface vethbr
+{
+        AdvSendAdvert on;
+        prefix dead:beef::/64
+        {
+                AdvOnLink on;
+        };
+
+};
+
+interface test1p
+{
+        AdvSendAdvert on;
+        prefix beef:dead::/64
+        {
+                AdvOnLink on;
+        };
+
+};


### PR DESCRIPTION
Check that NM can handle two default routes on the same device for
IPv6 requests coming from multiple radvd servers.

//bugzilla.redhat.com/show_bug.cgi?id=1445417

@Build:nm-1-10