### PR TITLE
general: update @preserve_failed_assumed_connections test

### DIFF
--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -835,11 +835,11 @@ Feature: nmcli - general
     * Execute "ip tuntap add BBB mode tap"
     * Execute "ip link set dev BBB up"
     * Execute "ip addr add 10.2.5.6/24 valid_lft 1024 preferred_lft 1024 dev BBB"
-    When "connecting" is visible with command "nmcli device show BBB" in "45" seconds
+    Then "10.2.5.6/24" is visible with command "ip addr show BBB" for full "50" seconds
     * Bring "down" connection "BBB"
     * Execute "ip link set dev BBB up"
     * Execute "ip addr add 10.2.5.6/24 dev BBB"
-    Then "connected" is visible with command "nmcli device show BBB" in "45" seconds
+    Then "10.2.5.6/24" is visible with command "ip addr show BBB" for full "10" seconds
 
 
     @rhbz1066705


### PR DESCRIPTION
Instead of checking that the device state is "connecting", just check
that the IP addresses is preserved. Until now, when NM found an
external connection with dynamic addresses, it started DHCP (ignoring
the result) and thus the device stayed in the "connecting" state.

Now NM no longer starts DHCP and the device goes to "connected" state
directly.

@Build:nm-1-10

https://bugzilla.redhat.com/show_bug.cgi?id=1530288