### PR TITLE
ipv6: add 'ipv6_routes_with_src' test

### DIFF
--- a/nmcli/features/ipv6.feature
+++ b/nmcli/features/ipv6.feature
@@ -358,6 +358,18 @@
     Then "1010::1 dev eth1\s+proto static\s+metric 3" is visible with command "ip -6 route"
 
 
+    @rhbz1452684
+    @ipv6
+    @ver+=1.10
+    @ipv6_routes_with_src
+    Scenario: nmcli - ipv6 - routes - set route with src
+     * Add a new connection of type "ethernet" and options "ifname eth1 con-name ethie autoconnect no ipv6.method manual ipv6.addresses 2000::2/126 ipv6.route-metric 256"
+     * Execute "nmcli con modify ethie ipv6.routes '1010::1/128 src=2000::2'"
+     * Bring "up" connection "ethie"
+    Then "1010::1 dev eth1\s+proto static\s+metric 256" is visible with command "ip -6 route"
+     And "2000::\/126 dev eth1\s+proto kernel\s+metric 256" is visible with command "ip -6 route"
+
+
     @rhbz1436531
     @ver+=1.10
     @eth @flush_300

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -182,6 +182,7 @@ wait_for_slow_teamd, ., nmcli/./runtest.sh wait_for_slow_teamd ,
 #@ipv6_start
 ipv6_block_just_routing_RA, ., nmcli/./runtest.sh ipv6_block_just_routing_RA ,
 ipv6_limited_router_solicitation, ., nmcli/./runtest.sh ipv6_limited_router_solicitation ,
+ipv6_routes_with_src, ., nmcli/./runtest.sh ipv6_routes_with_src ,
 ipv6_route_set_route_with_tables, ., nmcli/./runtest.sh ipv6_route_set_route_with_tables ,
 ipv6_route_set_route_with_tables_reapply, ., nmcli/./runtest.sh ipv6_route_set_route_with_tables_reapply ,
 ipv6_correct_slaac_setting, ., nmcli/./runtest.sh ipv6_correct_slaac_setting ,


### PR DESCRIPTION
Check that NM can accept ipv6.routes '1010::1/128 src=2000::2'.

https://bugzilla.redhat.com/show_bug.cgi?id=1452684

@Build:nm-1-10