### PR TITLE
bond/ethernet: add 'nmclient_*_get_state_flags' tests

### DIFF
--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -1595,12 +1595,13 @@ def after_scenario(context, scenario):
         if 'teardown_testveth' in scenario.tags:
             print("---------------------------")
             print("removing testveth device setup for all test devices")
-            for ns in context.testvethns:
-                print("Removing the setup in %s namespace" % ns)
-                call('[ -f /tmp/%s.pid ] && ip netns exec %s kill -SIGCONT $(cat /tmp/%s.pid)' % (ns, ns, ns), shell=True)
-                call('[ -f /tmp/%s.pid ] && kill $(cat /tmp/%s.pid)' % (ns, ns) , shell=True)
-                call('ip netns del %s' % ns, shell=True)
-                call('ip link del %s' % ns.split('_')[0], shell=True)
+            if hasattr(context, 'testvethns'):
+                for ns in context.testvethns:
+                    print("Removing the setup in %s namespace" % ns)
+                    call('[ -f /tmp/%s.pid ] && ip netns exec %s kill -SIGCONT $(cat /tmp/%s.pid)' % (ns, ns, ns), shell=True)
+                    call('[ -f /tmp/%s.pid ] && kill $(cat /tmp/%s.pid)' % (ns, ns) , shell=True)
+                    call('ip netns del %s' % ns, shell=True)
+                    call('ip link del %s' % ns.split('_')[0], shell=True)
             call('rm -f /etc/udev/rules.d/88-lr.rules', shell=True)
             call('udevadm control --reload-rules', shell=True)
             call('udevadm settle', shell=True)

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -75,6 +75,7 @@ bond_leave_L2_only_up_when_going_down, ., nmcli/./runtest.sh bond_leave_L2_only_
 bond_assume_options_1, ., nmcli/./runtest.sh bond_assume_options_1 ,
 bond_assume_options_2, ., nmcli/./runtest.sh bond_assume_options_2 ,
 bond_assume_options_3, ., nmcli/./runtest.sh bond_assume_options_3 ,
+nmclient_bond_get_state_flags, ., nmcli/./runtest.sh nmclient_bond_get_state_flags ,
 #@bond_end
 
 #@bridge_start
@@ -420,6 +421,7 @@ preserve_8021x_leap_con, ., nmcli/./runtest.sh preserve_8021x_leap_con ,
 #openvswitch_ignore_ovs_network_setup, ., nmcli/./runtest.sh openvswitch_ignore_ovs_network_setup ,
 #openvswitch_ignore_ovs_vlan_network_setup, ., nmcli/./runtest.sh openvswitch_ignore_ovs_vlan_network_setup ,
 #openvswitch_ignore_ovs_bond_network_setup, ., nmcli/./runtest.sh openvswitch_ignore_ovs_bond_network_setup ,
+nmclient_ethernet_get_state_flags, ., nmcli/./runtest.sh nmclient_ethernet_get_state_flags ,
 #@ethernet_end
 
 

--- a/tmp/nmclient_get_state_flags.py
+++ b/tmp/nmclient_get_state_flags.py
@@ -1,0 +1,20 @@
+#! /usr/bin/python
+
+import sys
+import gi
+gi.require_version('NM', '1.0')
+from gi.repository import NM
+
+connection_name = sys.argv[1]
+nm_client = NM.Client.new(None)
+
+con = None
+for c in nm_client.get_active_connections():
+    if c.get_id() == connection_name:
+        con = c
+        break
+
+if con != None:
+    print(con.get_state_flags())
+else:
+    print("Error: no %s connection" %connection_name)


### PR DESCRIPTION
Check that nmclient correctly shows flags during profile connection
and that it reflects various situations correctly.

https://bugzilla.redhat.com/show_bug.cgi?id=1454883

@Build:nm-1-10