### PR TITLE
ipv4: add 'ipv4_set_very_long_dhcp_client_id' test

### DIFF
--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -432,7 +432,7 @@ def before_scenario(context, scenario):
             print ("---------------------------")
             print ("set internal DHCP")
             call("printf '# configured by beaker-test\n[main]\ndhcp=internal\n' > /etc/NetworkManager/conf.d/99-xtest-dhcp-internal.conf", shell=True)
-            call('systemctl restart NetworkManager.service', shell=True)
+            call('systemctl reload NetworkManager.service', shell=True)
 
         if 'dhcpd' in scenario.tags:
             print ("---------------------------")
@@ -866,10 +866,15 @@ def after_scenario(context, scenario):
 
         if 'restart' in scenario.tags:
             print ("---------------------------")
-            print ("restarting NM service")
-            call('sudo service NetworkManager restart', shell=True)
-            sleep(2)
-            restore_testeth0()
+            print ("restart/reload NM service")
+            if call('systemctl is-active NetworkManager', shell=True) == 0:
+                print ("* just reload")
+                call('sudo systemctl reload NetworkManager', shell=True)
+            else:
+                print ("* need to restart")
+                call('sudo systemctl restart NetworkManager', shell=True)
+                sleep(2)
+            wait_for_testeth0()
         dump_status(context, 'after %s' % scenario.name)
 
         if '1000' in scenario.tags:
@@ -1074,7 +1079,7 @@ def after_scenario(context, scenario):
             print ("---------------------------")
             print ("revert internal DHCP")
             call("rm -f /etc/NetworkManager/conf.d/99-xtest-dhcp-internal.conf", shell=True)
-            call('systemctl restart NetworkManager.service', shell=True)
+            call('systemctl reload NetworkManager.service', shell=True)
 
         if 'dhcpd' in scenario.tags:
             print ("---------------------------")

--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1142,6 +1142,17 @@ Feature: nmcli: ipv4
     Then "BC" is not visible with command "cat /tmp/tshark.log"
 
 
+    @rhbz1531173
+    @ver+=1.10
+    @eth9 @ipv4 @internal_DHCP @restart
+    @ipv4_set_very_long_dhcp_client_id
+    Scenario: nmcli - ipv4 - dhcp-client-id - set long client id
+    * Add connection type "ethernet" named "ethie" for device "eth9"
+    * Bring "down" connection "ethie"
+    * Execute "nmcli connection modify ethie ipv4.dhcp-client-id $(printf '=%.0s' {1..999})"
+    Then Bring "up" connection "ethie"
+
+
     @ipv4
     @ipv4_may-fail_yes
     Scenario: nmcli - ipv4 - may-fail - set true

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -317,6 +317,7 @@ ipv4_dns-search_ignore_auto_routes, ., nmcli/./runtest.sh ipv4_dns-search_ignore
 ipv4_method_link-local, ., nmcli/./runtest.sh ipv4_method_link-local ,
 ipv4_dhcp_client_id_set, ., nmcli/./runtest.sh ipv4_dhcp_client_id_set ,
 ipv4_dhcp_client_id_remove, ., nmcli/./runtest.sh ipv4_dhcp_client_id_remove ,
+ipv4_set_very_long_dhcp_client_id, ., nmcli/./runtest.sh ipv4_set_very_long_dhcp_client_id ,
 ipv4_may-fail_yes, ., nmcli/./runtest.sh ipv4_may-fail_yes ,
 ipv4_method_disabled, ., nmcli/./runtest.sh ipv4_method_disabled ,
 ipv4_never-default_set, ., nmcli/./runtest.sh ipv4_never-default_set ,


### PR DESCRIPTION
Check that NM can handle dhcp-client-id longer than 133 characters
under internal dhcp client.

Test uses 999 chars.

https://bugzilla.redhat.com/show_bug.cgi?id=1531173

@Build:nm-1-10