### PR TITLE
ipv4: add 'ipv4_restore_default_route_externally' test

### DIFF
--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -392,6 +392,20 @@ Feature: nmcli: ipv4
      And "192.168.100.0\/24 dev eth1 proto kernel scope link src 192.168.100.* metric 10[0-2]" is visible with command "ip r show"
 
 
+    @rhbz1503769
+    @ver+=1.10
+    @ethie
+    @ipv4_restore_default_route_externally
+    Scenario: nmcli - ipv4 - routes - restore externally
+    * Add a new connection of type "ethernet" and options "ifname eth1 con-name ethie"
+    When "connected" is visible with command "nmcli -g state,device device |grep eth1$" in "20" seconds
+     And "default" is visible with command "ip r |grep eth1"
+    * Execute "ip route delete default dev eth1"
+    When "default" is not visible with command "ip r |grep eth1"
+    * Execute "ip route add default via 192.168.100.1 metric 103"
+    Then "default" is visible with command "ip r |grep eth1"
+
+
     @rhbz1164441
     @ver-=1.10.0
     @ipv4_2

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -280,6 +280,7 @@ ipv4_route_set_route_with_src_new_syntax_restart_persistence, ., nmcli/./runtest
 no_metric_route_connection_restart_persistence, ., nmcli/./runtest.sh no_metric_route_connection_restart_persistence ,
 ipv4_route_set_route_with_tables, ., nmcli/./runtest.sh ipv4_route_set_route_with_tables ,
 ipv4_route_set_route_with_tables_reapply, ., nmcli/./runtest.sh ipv4_route_set_route_with_tables_reapply ,
+ipv4_restore_default_route_externally, ., nmcli/./runtest.sh ipv4_restore_default_route_externally ,
 ipv4_route_remove_basic_route, ., nmcli/./runtest.sh ipv4_route_remove_basic_route ,
 ipv4_route_set_device_route, ., nmcli/./runtest.sh ipv4_route_set_device_route ,
 ipv4_host_destination_route, ., nmcli/./runtest.sh ipv4_host_destination_route ,


### PR DESCRIPTION
Check that NM is OK with externally readded default route as it
always was.

https://bugzilla.redhat.com/show_bug.cgi?id=1503769

@Build:nm-1-10