### PR TITLE
nmclient: add 'nmcli_get_wireless_hw_property' test

### DIFF
--- a/nmcli/features/wifi_hwsim.feature
+++ b/nmcli/features/wifi_hwsim.feature
@@ -142,3 +142,11 @@ Feature: nmcli - wifi
     * Add a new connection of type "wifi" and options "ifname wlan0 con-name wifi autoconnect no ssid wpa2-eap 802-11-wireless-security.key-mgmt wpa-eap 802-1x.eap ttls 802-1x.identity test_gtc 802-1x.anonymous-identity test 802-1x.ca-cert /tmp/certs/test_user.ca.pem 802-1x.phase2-autheap gtc 802-1x.password password"
     * Execute "sleep 1"
     Then Bring "up" connection "wifi"
+
+
+    @rhbz1520398
+    @ver+=1.10
+    @simwifi_wpa2
+    @nmclient_get_wireless_hw_property
+    Scenario: nmclient - property - get wireless hardware property
+    Then "True|False" is visible with command "python tmp/nmclient_get_property.py wireless-hardware-enabled"

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -688,6 +688,7 @@ simwifi_ttls_mschapv2, ., nmcli/./runtest.sh simwifi_ttls_mschapv2 ,
 simwifi_ttls_mschapv2_eap, ., nmcli/./runtest.sh simwifi_ttls_mschapv2_eap ,
 simwifi_ttls_md5, ., nmcli/./runtest.sh simwifi_ttls_md5 ,
 simwifi_ttls_gtc, ., nmcli/./runtest.sh simwifi_ttls_gtc ,
+nmclient_get_wireless_hw_property, ., nmcli/./runtest.sh nmclient_get_wireless_hw_property ,
 #@wifi_hwsim_end
 
 #@wifi_start

--- a/tmp/nmclient_get_property.py
+++ b/tmp/nmclient_get_property.py
@@ -1,0 +1,11 @@
+#! /usr/bin/python
+
+import sys
+import gi
+gi.require_version('NM', '1.0')
+from gi.repository import NM
+
+prop = sys.argv[1]
+nm_client = NM.Client.new(None)
+
+print(nm_client.get_property(prop))


### PR DESCRIPTION
Check that wireless-hardware-enabled can be properly read from
manager.

https://bugzilla.redhat.com/show_bug.cgi?id=1520398

@Build:nm-1-10