### PR TITLE
bridge/general: add device overtaking and bridge deleting tests

### DIFF
--- a/nmcli/features/bridge.feature
+++ b/nmcli/features/bridge.feature
@@ -487,3 +487,22 @@ Feature: nmcli - bridge
       And "connection.slave-type:\s+bridge" is not visible with command "nmcli c s ethie | grep 'slave-type:'"
       And "BRIDGE" is not visible with command "grep BRIDGE /etc/sysconfig/network-scripts/ifcfg-ethie"
       And Bring "up" connection "ethie"
+
+
+    @ver+=1.10
+    @bridge
+    @bridge_delete_connection_with_device
+    Scenario: nmcli - bridge - delete with device
+    * Add a new connection of type "bridge" and options "con-name bridge0 ifname bridge0 autoconnect yes ip4 192.168.1.19/24"
+    * Delete connection "bridge0"
+    Then "bridge0" is not visible with command "nmcli dev"
+
+
+    @ver+=1.10
+    @bridge @restart
+    @bridge_delete_connection_without_device
+    Scenario: nmcli - bridge - delete without device
+    * Add a new connection of type "bridge" and options "con-name bridge0 ifname bridge0 autoconnect yes ip4 192.168.1.19/24"
+    * Reboot
+    * Delete connection "bridge0"
+    Then "bridge0" is visible with command "nmcli dev"

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -1522,7 +1522,7 @@ def after_scenario(context, scenario):
         if 'add_testeth1' in scenario.tags:
             print ("---------------------------")
             print ("restoring testeth1 profile")
-            call('sudo nmcli connection delete eth1 eth1 eth1', shell=True)
+            call('sudo nmcli connection delete eth1 eth1 eth1 testeth1', shell=True)
             call('sudo nmcli connection add type ethernet con-name testeth1 ifname eth1 autoconnect no', shell=True)
 
         if 'eth1_disconnect' in scenario.tags:

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1570,3 +1570,18 @@ Feature: nmcli - general
     * Execute "sleep 2"
     * Execute "ip link set tap0 down"
     Then "master br0" is visible with command "ip link show tap0" for full "5" seconds
+
+
+    @ver+=1.10
+    @add_testeth1 @eth1_disconnect
+    @overtake_external_device
+    Scenario: nmcli - general - overtake external device
+    * Execute "ip add add 1.2.3.4/24 dev eth1"
+    When "No such file" is visible with command "cat /etc/sysconfig/network-scripts/ifcfg-eth1"
+     And "eth1" is visible with command "nmcli -g NAME connection" in "5" seconds
+     And "dhclient" is not visible with command "ps aux|grep dhcl |grep eth1"
+    * Execute "nmcli con modify eth1 ipv4.method auto"
+    When "activated" is visible with command "nmcli -g GENERAL.STATE con show eth1" in "20" seconds
+     And "BOOTPROTO=dhcp" is visible with command "cat /etc/sysconfig/network-scripts/ifcfg-eth1"
+     And "dhclient" is visible with command "ps aux|grep dhcl |grep eth1"
+     And "192.168" is visible with command "ip a s eth1" in "20" seconds

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -112,6 +112,8 @@ bridge_set_mac_var2, ., nmcli/./runtest.sh bridge_set_mac_var2, bridge-utils
 bridge_external_unmanaged, ., nmcli/./runtest.sh bridge_external_unmanaged, bridge-utils
 bridge_preserve_assumed_connection_ips, ., nmcli/./runtest.sh bridge_preserve_assumed_connection_ips ,
 bridge_slave_to_ethernet_conversion, ., nmcli/./runtest.sh bridge_slave_to_ethernet_conversion ,
+bridge_delete_connection_with_device, ., nmcli/./runtest.sh bridge_delete_connection_with_device ,
+bridge_delete_connection_without_device, ., nmcli/./runtest.sh bridge_delete_connection_without_device ,
 #@bridge_end
 
 #@team_start
@@ -526,6 +528,7 @@ connectivity_check, ., nmcli/./runtest.sh connectivity_check ,
 disable_connectivity_check, ., nmcli/./runtest.sh disable_connectivity_check ,
 per_device_connectivity_check, ., nmcli/./runtest.sh per_device_connectivity_check ,
 keep_external_device_enslaved_on_down, ., nmcli/./runtest.sh keep_external_device_enslaved_on_down ,
+overtake_external_device, ., nmcli/./runtest.sh overtake_external_device ,
 #@general_end
 
 #@wol_start


### PR DESCRIPTION
 * Check that NM can overtake device by changing method to auto.
   https://bugzilla.redhat.com/show_bug.cgi?id=1462223

 * Add two tests to check whether device is deleted with connection
  depending if it existed before NM start or not.

@Build:nm-1-10