### PR TITLE
general: add 'wait_10s_for_flappy_carrier' test

### DIFF
--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1635,3 +1635,17 @@ Feature: nmcli - general
      And "BOOTPROTO=dhcp" is visible with command "cat /etc/sysconfig/network-scripts/ifcfg-eth1"
      And "dhclient" is visible with command "ps aux|grep dhcl |grep eth1"
      And "192.168" is visible with command "ip a s eth1" in "20" seconds
+
+
+    @rhbz1487702
+    @ver+=1.10
+    @eth @no_config_server @teardown_testveth @restart
+    @wait_10s_for_flappy_carrier
+    Scenario: NM - general - wait for flappy carrier up to 10s
+    * Add a new connection of type "ethernet" and options "ifname testX con-name ethie autoconnect no 802-3-ethernet.mtu 9000"
+    * Prepare simulated test "testX" device
+    * Run child "nmcli con up ethie"
+    * Execute "ip link set testX down"
+    * Execute "sleep 8"
+    * Execute "ip link set testX up"
+    When "activated" is visible with command "nmcli -g GENERAL.STATE con show ethie" in "10" seconds

--- a/prepare/devsetup.sh
+++ b/prepare/devsetup.sh
@@ -132,7 +132,7 @@ local_setup_configure_nm_eth () {
             fi
 
             yum -y install NetworkManager-config-server
-            cp /usr/lib/NetworkManager/conf.d/00-server.conf /etc/NetworkManager/conf.d/00-server.conf
+            #cp /usr/lib/NetworkManager/conf.d/00-server.conf /etc/NetworkManager/conf.d/00-server.conf
         fi
 
         if [ $wlan -eq 1 ]; then

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -531,6 +531,7 @@ manipulate_connectivity_check_via_dbus, ., nmcli/./runtest.sh manipulate_connect
 per_device_connectivity_check, ., nmcli/./runtest.sh per_device_connectivity_check ,
 keep_external_device_enslaved_on_down, ., nmcli/./runtest.sh keep_external_device_enslaved_on_down ,
 overtake_external_device, ., nmcli/./runtest.sh overtake_external_device ,
+wait_10s_for_flappy_carrier, ., nmcli/./runtest.sh wait_10s_for_flappy_carrier ,
 #@general_end
 
 #@wol_start


### PR DESCRIPTION
Check that NM waits more than 8 seconds when carrier is flapped
 during mtu change for example.

https://bugzilla.redhat.com/show_bug.cgi?id=1487702

@Build:nm-1-10