### PR TITLE
Devel/vb/wifi scan radnomization

### DIFF
--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -748,12 +748,6 @@ def before_scenario(context, scenario):
             call('sudo systemctl restart NetworkManager.service', shell=True)
             sleep(5)
 
-        if 'remove_custom_cfg' in scenario.tags:
-            print("---------------------------")
-            print("Removing custom cfg file in conf.d")
-            call('sudo rm -f /etc/NetworkManager/conf.d/99-xxcustom.conf', shell=True)
-            call('sudo systemctl restart NetworkManager.service', shell=True)
-
         if 'need_config_server' in scenario.tags:
             print("---------------------------")
             print("Making sure NetworkManager-config-server is installed")
@@ -1413,6 +1407,12 @@ def after_scenario(context, scenario):
             call('rm -rf /etc/dnsmasq.d/dnsmasq_custom.conf', shell=True)
             call('systemctl restart NetworkManager', shell=True)
             call("nmcli con up testeth0", shell=True)
+
+        if 'remove_custom_cfg' in scenario.tags:
+            print("---------------------------")
+            print("Removing custom cfg file in conf.d")
+            call('sudo rm -f /etc/NetworkManager/conf.d/99-xxcustom.conf', shell=True)
+            call('sudo systemctl restart NetworkManager.service', shell=True)
 
         if 'ipv6_describe' in scenario.tags or 'ipv4_describe' in scenario.tags:
             if call("systemctl is-enabled beah-srv.service  |grep ^enabled", shell=True) == 0:

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -52,7 +52,8 @@ def dump_status(context, when):
             call(cmd, shell=True, stdout=context.log)
     else:
         for cmd in ['ip addr', 'ip -4 route', 'ip -6 route',
-            'nmcli g', 'nmcli c', 'nmcli d', 'nmcli -f IN-USE,SSID,CHAN,SIGNAL,SECURITY d w', 'hostnamectl']:
+            'nmcli g', 'nmcli c', 'nmcli d', 'nmcli -f IN-USE,SSID,CHAN,SIGNAL,SECURITY d w',
+            'hostnamectl', 'NetworkManager --print-config']:
             #'nmcli con show testeth0',\
             #'sysctl -a|grep ra |grep ipv6 |grep "all\|default\|eth\|test"']:
             context.log.write("--- %s ---\n" % cmd)

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1060,7 +1060,7 @@ Feature: nmcli - general
     * Add a new connection of type "ethernet" and options "ifname testX con-name ethie"
     * Stop NM
     * Prepare simulated veth device "testX" wihout carrier
-    * Execute "echo '[device-testX]' >> /etc/NetworkManager/conf.d/99-xxcustom.conf"
+    * Execute "echo '[device-testX]' > /etc/NetworkManager/conf.d/99-xxcustom.conf"
     * Execute "echo 'match-device=interface-name:testX' >> /etc/NetworkManager/conf.d/99-xxcustom.conf"
     * Execute "echo 'carrier-wait-timeout=15000' >> /etc/NetworkManager/conf.d/99-xxcustom.conf"
     * Execute "sleep 1"

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1060,7 +1060,7 @@ Feature: nmcli - general
     * Add a new connection of type "ethernet" and options "ifname testX con-name ethie"
     * Stop NM
     * Prepare simulated veth device "testX" wihout carrier
-    * Execute "echo '[device]' >> /etc/NetworkManager/conf.d/99-xxcustom.conf"
+    * Execute "echo '[device-testX]' >> /etc/NetworkManager/conf.d/99-xxcustom.conf"
     * Execute "echo 'match-device=interface-name:testX' >> /etc/NetworkManager/conf.d/99-xxcustom.conf"
     * Execute "echo 'carrier-wait-timeout=15000' >> /etc/NetworkManager/conf.d/99-xxcustom.conf"
     * Execute "sleep 1"

--- a/prepare/hostapd_wireless.sh
+++ b/prepare/hostapd_wireless.sh
@@ -122,9 +122,9 @@ function wireless_hostapd_setup ()
             systemctl restart haveged
 
             # Disable mac randomization to avoid rhbz1490885
-            echo -e "[device]\nwifi.scan-rand-mac-address=no" > /etc/NetworkManager/conf.d/99-wifi.conf
-            echo -e "[connection]\nwifi.cloned-mac-address=preserve" >> /etc/NetworkManager/conf.d/99-wifi.conf
-            
+            echo -e "[device-wifi]\nwifi.scan-rand-mac-address=no" > /etc/NetworkManager/conf.d/99-wifi.conf
+            echo -e "[connection-wifi]\nwifi.cloned-mac-address=preserve" >> /etc/NetworkManager/conf.d/99-wifi.conf
+
             modprobe mac80211_hwsim
             sleep 5
             tune_wpa_supplicant

--- a/prepare/hostapd_wireless.sh
+++ b/prepare/hostapd_wireless.sh
@@ -32,8 +32,6 @@ function tune_wpa_supplicant ()
     cp -rf /usr/lib/systemd/system/wpa_supplicant.service /etc/systemd/system/wpa_supplicant.service
     sed -i 's!ExecStart=/usr/sbin/wpa_supplicant -u -f /var/log/wpa_supplicant.log -c /etc/wpa_supplicant/wpa_supplicant.conf!ExecStart=/usr/sbin/wpa_supplicant -u -c /etc/wpa_supplicant/wpa_supplicant.conf!' /etc/systemd/system/wpa_supplicant.service
     sed -i 's!OTHER_ARGS="-P /var/run/wpa_supplicant.pid"!OTHER_ARGS="-P /var/run/wpa_supplicant.pid -ddddK"!' /etc/sysconfig/wpa_supplicant
-    systemctl daemon-reload
-    systemctl restart wpa_supplicant
 
 }
 
@@ -93,6 +91,13 @@ function copy_certificates ()
     update-ca-trust extract
 }
 
+function restart_services ()
+{
+    systemctl daemon-reload
+    systemctl restart wpa_supplicant
+    systemctl restart NetworkManager
+}
+
 function start_nm_hostapd ()
 {
     systemd-run --unit nm-hostapd hostapd -ddd $HOSTAPD_CFG
@@ -118,11 +123,11 @@ function wireless_hostapd_setup ()
 
             # Disable mac randomization to avoid rhbz1490885
             echo -e "[device]\nwifi.scan-rand-mac-address=no" > /etc/NetworkManager/conf.d/99-wifi.conf
-            systemctl restart NetworkManager
 
             modprobe mac80211_hwsim
             sleep 5
             tune_wpa_supplicant
+            restart_services
             sleep 10
             nmcli device set wlan1 managed off
             ip add add 10.0.0.1/24 dev wlan1

--- a/prepare/hostapd_wireless.sh
+++ b/prepare/hostapd_wireless.sh
@@ -123,7 +123,8 @@ function wireless_hostapd_setup ()
 
             # Disable mac randomization to avoid rhbz1490885
             echo -e "[device]\nwifi.scan-rand-mac-address=no" > /etc/NetworkManager/conf.d/99-wifi.conf
-
+            echo -e "[connection]\nwifi.cloned-mac-address=preserve" >> /etc/NetworkManager/conf.d/99-wifi.conf
+            
             modprobe mac80211_hwsim
             sleep 5
             tune_wpa_supplicant


### PR DESCRIPTION
Use different sections [device-testX] and [device-wifi] to not mix stuff together as otherwise mixed (and often unfunctional) configurations may be created.

@Build-nm-1-10