### PR TITLE
ipv4: add test to check persistent lease renewal

### DIFF
--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1280,6 +1280,21 @@ Feature: nmcli: ipv4
     Then "default via 192.168.99.1 dev testX" is visible with command "ip r"
 
 
+    @rhbz1503587
+    @eth @teardown_testveth @long
+    @renewal_gw_after_long_dhcp_outage
+    Scenario: NM - ipv4 - renewal gw after DHCP outage
+    * Prepare simulated test "testX" device
+    * Add connection type "ethernet" named "ethie" for device "testX"
+    * Bring "up" connection "ethie"
+    * Execute "ip netns exec testX_ns kill -SIGSTOP $(cat /tmp/testX_ns.pid)"
+    When "default" is not visible with command "ip r |grep testX" in "130" seconds
+    * Execute "sleep 500"
+    * Execute "ip netns exec testX_ns kill -SIGCONT $(cat /tmp/testX_ns.pid)"
+    Then "routers = 192.168.99.1" is visible with command "nmcli con show ethie" in "130" seconds
+    Then "default via 192.168.99.1 dev testX" is visible with command "ip r"
+
+
     @rhbz1262922
     @ver+=1.2.0
     @eth @teardown_testveth

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -329,6 +329,7 @@ ipv4_never-default_remove, ., nmcli/./runtest.sh ipv4_never-default_remove ,
 ipv4_describe, ., nmcli/./runtest.sh ipv4_describe ,
 set_mtu_from_DHCP, ., nmcli/./runtest.sh set_mtu_from_DHCP ,
 renewal_gw_after_dhcp_outage, ., nmcli/./runtest.sh renewal_gw_after_dhcp_outage ,,20m
+renewal_gw_after_long_dhcp_outage, ., nmcli/./runtest.sh renewal_gw_after_long_dhcp_outage ,,20m
 dhcp-timeout, ., nmcli/./runtest.sh dhcp-timeout ,
 dhcp-timeout_infinity, ., nmcli/./runtest.sh dhcp-timeout_infinity ,
 timeout_default_in_cfg, ., nmcli/./runtest.sh timeout_default_in_cfg ,


### PR DESCRIPTION
This checks that when ipv6 is configured but ipv4 loose the lease as DHCP is unreachable, the lease is attempted to be renewed forever (more than the scheduled 3 times, as done when may-fail is no).
Just fixed on master and nm-1-10 (expected to fail in nm-1-8).

@Build:nm-1-10