### PR TITLE
ipv4: don't check metric in device_reapply_routes in 1.11+

### DIFF
--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -401,7 +401,7 @@ Feature: nmcli - general
      And "default via 192.168.99.1 dev testX" is visible with command "ip r"
 
 
-    @ver+=1.10.2
+    @ver+=1.10.2  @ver-1.11
     @eth @teardown_testveth @two_bridged_veths @dhcpd
     @device_reapply_routes
     Scenario: NM - device - reapply just routes
@@ -421,6 +421,30 @@ Feature: nmcli - general
      And "192.168.5.0/24 via 192.168.99.111 dev testX\s+proto static\s+metric" is visible with command "ip route"
      And "routers = 192.168.99.1" is visible with command "nmcli con show ethie"
      And "default via 192.168.99.1 dev testX\s+proto dhcp\s+metric 21" is visible with command "ip r"
+
+
+    @ver+=1.11
+    @eth @teardown_testveth @two_bridged_veths @dhcpd
+    @device_reapply_routes
+    Scenario: NM - device - reapply just routes
+    * Prepare simulated test "testX" device
+    * Add a new connection of type "ethernet" and options "ifname testX con-name ethie autoconnect no"
+    * Bring "up" connection "ethie"
+    * Open editor for connection "ethie"
+    * Submit "set ipv4.routes 192.168.5.0/24 192.168.99.111 1" in editor
+    * Submit "set ipv4.route-metric 21" in editor
+    * Submit "set ipv6.method static" in editor
+    * Submit "set ipv6.addresses 2000::2/126" in editor
+    * Submit "set ipv6.routes 1010::1/128 2000::1 1" in editor
+    * Save in editor
+    * Execute "nmcli device reapply testX"
+    Then "1010::1 via 2000::1 dev testX\s+proto static\s+metric 1" is visible with command "ip -6 route" in "5" seconds
+     And "2000::/126 dev testX\s+proto kernel\s+metric 101" is visible with command "ip -6 route"
+     And "192.168.5.0/24 via 192.168.99.111 dev testX\s+proto static\s+metric" is visible with command "ip route"
+     And "routers = 192.168.99.1" is visible with command "nmcli con show ethie"
+     # Metric still cannot be changed when dhcp is used. Bug #1528071
+     # And "default via 192.168.99.1 dev testX\s+proto dhcp\s+metric 21" is visible with command "ip r"
+     And "default via 192.168.99.1 dev testX\s+proto dhcp\s+metric" is visible with command "ip r"
 
 
     @rhbz1032717


### PR DESCRIPTION
Unless https://bugzilla.redhat.com/show_bug.cgi?id=1528071 is resolved
we cannot check metric as it is not updated for dhcp based connections.

@Build:master