### PR TITLE
ipv4: add 'dhcp4_outages_in_various_situation' test

### DIFF
--- a/nmcli/features/ipv6.feature
+++ b/nmcli/features/ipv6.feature
@@ -400,7 +400,7 @@
 
     @rhbz1436531
     @ver+=1.10
-    @ver-1.11
+    @ver-=1.10.99
     @eth @flush_300
     @ipv6_route_set_route_with_tables_reapply
     Scenario: nmcli - ipv6 - routes - set route with tables reapply

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -336,6 +336,7 @@ timeout_default_in_cfg, ., nmcli/./runtest.sh timeout_default_in_cfg ,
 renewal_gw_after_dhcp_outage_for_assumed_var0, ., nmcli/./runtest.sh renewal_gw_after_dhcp_outage_for_assumed_var0 ,
 renewal_gw_after_dhcp_outage_for_assumed_var1, ., nmcli/./runtest.sh renewal_gw_after_dhcp_outage_for_assumed_var1 ,
 manual_routes_preserved_when_never-default_yes, ., nmcli/./runtest.sh manual_routes_preserved_when_never-default_yes ,
+dhcp4_outages_in_various_situation, ., nmcli/./runtest.sh dhcp4_outages_in_various_situation ,,20m
 manual_routes_removed_when_never-default_no, ., nmcli/./runtest.sh manual_routes_removed_when_never-default_no ,
 ipv4_dad, ., nmcli/./runtest.sh ipv4_dad ,
 custom_shared_range_preserves_restart, ., nmcli/./runtest.sh custom_shared_range_preserves_restart, dhcp


### PR DESCRIPTION
This test merges various tests together to save time
 * renewal_gw_after_dhcp_outage_for_assumed_var1
 * renewal_gw_after_dhcp_outage_for_assumed_var0
 * renewal_gw_after_long_dhcp_outage
 * renewal_gw_after_dhcp_outage

Those old tests shouldn't be running since 1.11+

@Build:master