### PR TITLE
ipv4: add test for DHCP NAK after expiry

### DIFF
--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1493,6 +1493,22 @@ Feature: nmcli: ipv4
     Then "default via 192.168.* dev testZ" is visible with command "ip r"
 
 
+    @eth @teardown_testveth @long
+    @ver+=1.11
+    @dhcp_change_pool
+    Scenario: NM - ipv4 - renewal after changed DHCP pool
+    # Check that the address is renewed immediately after a NAK
+    # from server due to changed configuration.
+    # https://bugzilla.gnome.org/show_bug.cgi?id=783391
+    * Prepare simulated test "testX" device with "192.168.99" ipv4 and "2620:cafe" ipv6 dhcp address prefix
+    * Add connection type "ethernet" named "ethie" for device "testX"
+    * Execute "nmcli connection modify ethie ipv4.may-fail no ipv6.method ignore"
+    * Bring "up" connection "ethie"
+    When "default via 192.168.99.1 dev testX" is visible with command "ip r"
+    * Restart dhcp server on "testX" device with "192.168.98" ipv4 and "2620:cafe" ipv6 dhcp address prefix
+    Then "default via 192.168.98.1 dev testX" is visible with command "ip r" in "130" seconds
+
+
     @rhbz1205405
     @eth @teardown_testveth @long
     @manual_routes_preserved_when_never-default_yes

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -337,6 +337,7 @@ renewal_gw_after_dhcp_outage_for_assumed_var0, ., nmcli/./runtest.sh renewal_gw_
 renewal_gw_after_dhcp_outage_for_assumed_var1, ., nmcli/./runtest.sh renewal_gw_after_dhcp_outage_for_assumed_var1 ,
 manual_routes_preserved_when_never-default_yes, ., nmcli/./runtest.sh manual_routes_preserved_when_never-default_yes ,
 dhcp4_outages_in_various_situation, ., nmcli/./runtest.sh dhcp4_outages_in_various_situation ,,20m
+dhcp_change_pool, ., nmcli/./runtest.sh dhcp_change_pool ,
 manual_routes_removed_when_never-default_no, ., nmcli/./runtest.sh manual_routes_removed_when_never-default_no ,
 ipv4_dad, ., nmcli/./runtest.sh ipv4_dad ,
 custom_shared_range_preserves_restart, ., nmcli/./runtest.sh custom_shared_range_preserves_restart, dhcp


### PR DESCRIPTION
Check that we can obtain a new lease immediately after a DHCP NAK.

https://bugzilla.gnome.org/show_bug.cgi?id=783391