### PR TITLE
ipv6: fix @ipv6_add_static_address_manually_not_active to not expect …

### DIFF
--- a/nmcli/features/ipv6.feature
+++ b/nmcli/features/ipv6.feature
@@ -1043,6 +1043,28 @@
 
     @rhbz1083133 @rhbz1098319 @rhbz1127718
     @veth @eth1_disconnect
+    @ver-=1.11.1
+    @ipv6_add_static_address_manually_not_active
+    Scenario: NM - ipv6 - add a static address manually to non-active interface (legacy 1.10 behavior and older)
+    Given "testeth1" is visible with command "nmcli connection"
+    Given "eth1\s+ethernet\s+connected" is not visible with command "nmcli device"
+    Given "state UP" is visible with command "ip a s eth1"
+    * "0" is visible with command "cat /proc/sys/net/ipv6/conf/eth1/disable_ipv6"
+    * Execute "ip -6 addr add 2001::dead:beef:01/64 dev eth1"
+    Then "0" is visible with command "cat /proc/sys/net/ipv6/conf/eth1/disable_ipv6"
+    Then "inet6 2001::dead:beef:1/64 scope global" is visible with command "ip a s eth1"
+    # Newer versions of NM no longer create IPv6 LL addresses for externally assumed devices.
+    # This test is obsoleted by @ipv6_add_static_address_manually_not_active_2, but this
+    # behavior won't be backported to older versions.
+    Then "addrgenmode none " is visible with command "ip -d l show eth1"
+    Then "inet6 fe80" is visible with command "ip a s eth1" in "5" seconds
+    # the assumed connection is created, give just some time for DAD to complete
+    Then "eth1\s+ethernet\s+connected\s+eth1" is visible with command "nmcli device" in "5" seconds
+
+
+    @rhbz1083133 @rhbz1098319 @rhbz1127718
+    @veth @eth1_disconnect
+    @ver+=1.11.2
     @ipv6_add_static_address_manually_not_active
     Scenario: NM - ipv6 - add a static address manually to non-active interface
     Given "testeth1" is visible with command "nmcli connection"
@@ -1052,7 +1074,14 @@
     * Execute "ip -6 addr add 2001::dead:beef:01/64 dev eth1"
     Then "0" is visible with command "cat /proc/sys/net/ipv6/conf/eth1/disable_ipv6"
     Then "inet6 2001::dead:beef:1/64 scope global" is visible with command "ip a s eth1"
-    Then "inet6 fe80" is visible with command "ip a s eth1" in "5" seconds
+    #
+    # the connection is assumed externally, meaning it has "addrgenmode none". NM is not
+    # interferring with the device, hence there is no IPv6 LL address. Which is a problem,
+    # but a problem of the user who takes over the device without setting the addrgenmode
+    # to its liking.
+    Then "addrgenmode none " is visible with command "ip -d l show eth1"
+    Then "inet6 fe80" is not visible with command "ip a s eth1"
+    #
     # the assumed connection is created, give just some time for DAD to complete
     Then "eth1\s+ethernet\s+connected\s+eth1" is visible with command "nmcli device" in "5" seconds
 

--- a/nmcli/features/ipv6.feature
+++ b/nmcli/features/ipv6.feature
@@ -1063,27 +1063,27 @@
 
 
     @rhbz1083133 @rhbz1098319 @rhbz1127718
-    @veth @eth1_disconnect
+    @veth @eth3_disconnect
     @ver+=1.11.2
     @ipv6_add_static_address_manually_not_active
     Scenario: NM - ipv6 - add a static address manually to non-active interface
-    Given "testeth1" is visible with command "nmcli connection"
-    Given "eth1\s+ethernet\s+connected" is not visible with command "nmcli device"
-    Given "state UP" is visible with command "ip a s eth1"
-    * "0" is visible with command "cat /proc/sys/net/ipv6/conf/eth1/disable_ipv6"
-    * Execute "ip -6 addr add 2001::dead:beef:01/64 dev eth1"
-    Then "0" is visible with command "cat /proc/sys/net/ipv6/conf/eth1/disable_ipv6"
-    Then "inet6 2001::dead:beef:1/64 scope global" is visible with command "ip a s eth1"
+    Given "testeth3" is visible with command "nmcli connection"
+    Given "eth3\s+ethernet\s+connected" is not visible with command "nmcli device"
+    Given "state UP" is visible with command "ip a s eth3"
+    * "0" is visible with command "cat /proc/sys/net/ipv6/conf/eth3/disable_ipv6"
+    * Execute "ip -6 addr add 2001::dead:beef:01/64 dev eth3"
+    Then "0" is visible with command "cat /proc/sys/net/ipv6/conf/eth3/disable_ipv6"
+    Then "inet6 2001::dead:beef:1/64 scope global" is visible with command "ip a s eth3"
     #
     # the connection is assumed externally, meaning it has "addrgenmode none". NM is not
     # interferring with the device, hence there is no IPv6 LL address. Which is a problem,
     # but a problem of the user who takes over the device without setting the addrgenmode
     # to its liking.
-    Then "addrgenmode none " is visible with command "ip -d l show eth1"
-    Then "inet6 fe80" is not visible with command "ip a s eth1"
+    Then "addrgenmode none " is visible with command "ip -d l show eth3"
+    Then "inet6 fe80" is not visible with command "ip a s eth3"
     #
     # the assumed connection is created, give just some time for DAD to complete
-    Then "eth1\s+ethernet\s+connected\s+eth1" is visible with command "nmcli device" in "5" seconds
+    Then "eth3\s+ethernet\s+connected\s+eth3" is visible with command "nmcli device" in "5" seconds
 
 
     @rhbz1138426


### PR DESCRIPTION
…IPv6 link local address

Before https://github.com/NetworkManager/NetworkManager/pull/75 (1.11.1
and older), NetworkManager would also create link local addresses for
externally assumed devices. The previous version of the test correctly
tested that behavior. But I think this is not desired behavior.

Note, that commonly NetworkManager keeps disconnected devices IFF_UP,
with "addrgenmode none". That is a terrible hack, to get carrier change
events for the device without IPv6 (link local) addresses.

When the user starts externally configuring addresses on the interface,
NetworkManager noticies this and generates an externally assumed
connection. In this mode, NetworkManager must no longer interfere with
whatever the user is doing.

This also means, to not re-add the IPv6 link local address, although
that might be quite unexpected to the user. It is also a change in
behavior with 1.11.2.

@Build:master