### PR TITLE
bridge: test connection.autoconnect-slaves behavior

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -45,7 +45,7 @@ beaker-hardware:
 
 setup:
 
-cleanup: 
+cleanup:
 
 testmapper:
   default:
@@ -238,6 +238,10 @@ testmapper:
     - bridge_dhcp_config_with_multiple_ethernet_ports:
         feature: bridge
     - bridge_static_config_with_multiple_ethernet_ports:
+        feature: bridge
+    - bridge_autoconnect_slaves_all:
+        feature: bridge
+    - bridge_autoconnect_slaves_all_modified:
         feature: bridge
     - bridge_server_ingore_carrier_with_dhcp:
         feature: bridge

--- a/nmcli/features/bridge.feature
+++ b/nmcli/features/bridge.feature
@@ -315,7 +315,7 @@ Feature: nmcli - bridge
     # if the master is autoconnect-slaves, then it will forcefully activate all slaves,
     # even if the device is currently busy with another (non-slave) profile.
     * Add a new connection of type "ethernet" and options "ifname eth4 con-name bridge-nonslave-eth4 autoconnect no"
-    * Add a new connection of type "bridge" and options "ifname bridge0 con-name bridge0 autoconnect no connection.autoconnect-slaves yes"
+    * Add a new connection of type "bridge" and options "ifname bridge0 con-name bridge0 autoconnect no connection.autoconnect-slaves yes bridge.stp no"
     * Add a new connection of type "bridge-slave" and options "ifname eth4 con-name bridge-slave-eth4 master bridge0 autoconnect no"
     * Bring up connection "bridge-nonslave-eth4"
     Then "eth4\s+ethernet\s+connected\s+bridge-nonslave-eth4" is visible with command "nmcli d"
@@ -335,14 +335,10 @@ Feature: nmcli - bridge
     # This case is slightly different, because the currently active profile
     # is the slave profile itself, but it was activated as a non-slave profile.
     * Add a new connection of type "ethernet" and options "ifname eth4 con-name bridge-nonslave-eth4 autoconnect no"
-    * Add a new connection of type "bridge" and options "ifname bridge0 con-name bridge0 autoconnect no connection.autoconnect-slaves yes"
-    * Add a new connection of type "bridge-slave" and options "ifname eth4 con-name bridge-slave-eth4 master bridge0 autoconnect no"
     * Bring up connection "bridge-nonslave-eth4"
     Then "eth4\s+ethernet\s+connected\s+bridge-nonslave-eth4" is visible with command "nmcli d"
-    Then "bridge0" is not visible with command "nmcli d"
-    Then "bridge0" is not visible with command "ip l"
     * Execute "nmcli con modify bridge-nonslave-eth4 master bridge0 slave-type bridge"
-    * Bring up connection "bridge0"
+    * Add a new connection of type "bridge" and options "ifname bridge0 con-name bridge0 autoconnect yes connection.autoconnect-slaves yes bridge.stp no"
     Then "bridge0\s+bridge\s+connected\s+bridge0" is visible with command "nmcli d" in "10" seconds
     Then "eth4\s+ethernet\s+connected\s+bridge-nonslave-eth4" is visible with command "nmcli d"
     Then "eth4.*master bridge0" is visible with command "ip a s eth4"

--- a/nmcli/features/bridge.feature
+++ b/nmcli/features/bridge.feature
@@ -308,26 +308,28 @@ Feature: nmcli - bridge
     Then "br4:.*192.168.1.19" is visible with command "ip a" in "30" seconds
 
 
-    @bridge
     @rhbz1548265
+    @ver+=1.11.90
+    @bridge
     @bridge_autoconnect_slaves_all
     Scenario: nmcli - bridge - autoconnect-slaves connects also otherwise busy devices
     # if the master is autoconnect-slaves, then it will forcefully activate all slaves,
     # even if the device is currently busy with another (non-slave) profile.
     * Add a new connection of type "ethernet" and options "ifname eth4 con-name bridge-nonslave-eth4 autoconnect no"
-    * Add a new connection of type "bridge" and options "ifname bridge0 con-name bridge0 autoconnect no connection.autoconnect-slaves yes bridge.stp no"
-    * Add a new connection of type "bridge-slave" and options "ifname eth4 con-name bridge-slave-eth4 master bridge0 autoconnect no"
+    * Add a new connection of type "bridge" and options "ifname br15 con-name bridge4 autoconnect no connection.autoconnect-slaves yes bridge.stp no"
+    * Add a new connection of type "bridge-slave" and options "ifname eth4 con-name bridge-slave-eth4 master br15 autoconnect no"
     * Bring up connection "bridge-nonslave-eth4"
-    Then "eth4\s+ethernet\s+connected\s+bridge-nonslave-eth4" is visible with command "nmcli d"
-    Then "bridge0" is not visible with command "nmcli d"
-    Then "bridge0" is not visible with command "ip l"
-    * Bring up connection "bridge0"
-    Then "bridge0\s+bridge\s+connected\s+bridge0" is visible with command "nmcli d" in "10" seconds
-    Then "eth4\s+ethernet\s+connected\s+bridge-slave-eth4" is visible with command "nmcli d"
+    When "eth4\s+ethernet\s+connected\s+bridge-nonslave-eth4" is visible with command "nmcli d"
+     And "br15" is not visible with command "nmcli d"
+     And "br15" is not visible with command "ip l"
+    * Bring up connection "bridge4"
+    Then "br15\s+bridge\s+connected\s+bridge4" is visible with command "nmcli d" in "10" seconds
+     And "eth4\s+ethernet\s+connected\s+bridge-slave-eth4" is visible with command "nmcli d"
 
 
-    @bridge
     @rhbz1548265
+    @ver+=1.11.90
+    @bridge
     @bridge_autoconnect_slaves_all_modified
     Scenario: nmcli - bridge - autoconnect-slaves connects also otherwise busy devices
     # if the master is autoconnect-slaves, then it will forcefully activate all slaves,
@@ -336,12 +338,12 @@ Feature: nmcli - bridge
     # is the slave profile itself, but it was activated as a non-slave profile.
     * Add a new connection of type "ethernet" and options "ifname eth4 con-name bridge-nonslave-eth4 autoconnect no"
     * Bring up connection "bridge-nonslave-eth4"
-    Then "eth4\s+ethernet\s+connected\s+bridge-nonslave-eth4" is visible with command "nmcli d"
-    * Execute "nmcli con modify bridge-nonslave-eth4 master bridge0 slave-type bridge"
-    * Add a new connection of type "bridge" and options "ifname bridge0 con-name bridge0 autoconnect yes connection.autoconnect-slaves yes bridge.stp no"
-    Then "bridge0\s+bridge\s+connected\s+bridge0" is visible with command "nmcli d" in "10" seconds
-    Then "eth4\s+ethernet\s+connected\s+bridge-nonslave-eth4" is visible with command "nmcli d"
-    Then "eth4.*master bridge0" is visible with command "ip a s eth4"
+    When "eth4\s+ethernet\s+connected\s+bridge-nonslave-eth4" is visible with command "nmcli d"
+    * Execute "nmcli con modify bridge-nonslave-eth4 master br15 slave-type bridge"
+    * Add a new connection of type "bridge" and options "ifname br15 con-name bridge4 autoconnect yes connection.autoconnect-slaves yes bridge.stp no"
+    Then "br15\s+bridge\s+connected\s+bridge4" is visible with command "nmcli d" in "10" seconds
+     And "eth4\s+ethernet\s+connected\s+bridge-nonslave-eth4" is visible with command "nmcli d"
+     And "eth4.*master br15" is visible with command "ip a s eth4"
 
 
     @bridge

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -1350,7 +1350,7 @@ def after_scenario(context, scenario):
             print ("---------------------------")
             print ("deleting all possible bridge residues")
             call('sudo nmcli con del bridge4 bridge4.0 bridge4.1 nm-bridge eth4.80 eth4.90', shell=True)
-            call('sudo nmcli con del bridge-slave-eth4 bridge-slave-eth4.80', shell=True)
+            call('sudo nmcli con del bridge-slave-eth4 bridge-nonslave-eth4 bridge-slave-eth4.80', shell=True)
             call('sudo nmcli con del bridge0 bridge bridge.15 nm-bridge br88 br11 br12 br15 bridge-slave br15-slave br15-slave1 br15-slave2 br10 br10-slave', shell=True)
             call('ip link del bridge0', shell=True)
             reset_hwaddr('eth4')

--- a/testmapper.txt
+++ b/testmapper.txt
@@ -99,6 +99,8 @@ bridge_autoconnect_slaves_when_master_reconnected, ., nmcli/./runtest.sh bridge_
 bridge_dhcp_config_with_ethernet_port, ., nmcli/./runtest.sh bridge_dhcp_config_with_ethernet_port, bridge-utils
 bridge_dhcp_config_with_multiple_ethernet_ports, ., nmcli/./runtest.sh bridge_dhcp_config_with_multiple_ethernet_ports, bridge-utils
 bridge_static_config_with_multiple_ethernet_ports, ., nmcli/./runtest.sh bridge_static_config_with_multiple_ethernet_ports, bridge-utils
+bridge_autoconnect_slaves_all, ., nmcli/./runtest.sh bridge_autoconnect_slaves_all, bridge-utils
+bridge_autoconnect_slaves_all_modified, ., nmcli/./runtest.sh bridge_autoconnect_slaves_all_modified, bridge-utils
 bridge_server_ingore_carrier_with_dhcp, ., nmcli/./runtest.sh bridge_server_ingore_carrier_with_dhcp, bridge-utils
 bridge_reflect_changes_from_outside_of_NM, ., nmcli/./runtest.sh bridge_reflect_changes_from_outside_of_NM, bridge-utils
 bridge_assumed_connection_race, ., nmcli/./runtest.sh  bridge_assumed_connection_race, bridge-utils


### PR DESCRIPTION
autoconnect.slaves should forcefully activate all slaves, even if the
device is currently busy with another profile. That was the case already,
but slightly broken with [1].

This adds two tests, one a general test, and the other where the
profile that should be stolen for activation is the slave profile
itself, but activated previously as a non-slave before being modified.
This is the scenario of bug [2].

[1] https://cgit.freedesktop.org/NetworkManager/NetworkManager/commit/?id=0922a177385be188b9c9c8ad39c1068533f5a4b3
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1548265


The second test is not yet expected to pass on master, which is what [2] is all about.