### PR TITLE
ipv6: fix @ipv6_add_static_address_manually_not_active test to wait

### DIFF
--- a/nmcli/features/ipv6.feature
+++ b/nmcli/features/ipv6.feature
@@ -1084,10 +1084,10 @@
     # but a problem of the user who takes over the device without setting the addrgenmode
     # to its liking.
     Then "addrgenmode none " is visible with command "ip -d l show eth3"
-    Then "inet6 fe80" is not visible with command "ip a s eth3"
+    Then "inet6 fe80" is not visible with command "ip a s eth3" for full "5" seconds
     #
     # the assumed connection is created, give just some time for DAD to complete
-    Then "eth3\s+ethernet\s+connected\s+eth3" is visible with command "nmcli device" in "5" seconds
+    Then "eth3\s+ethernet\s+connected\s+eth3" is visible with command "nmcli device"
 
 
     @rhbz1138426


### PR DESCRIPTION
The test is supposed to check that NetworkManager does not add a link
local address. It needs to wait longer to ensure that this doesn't
happen. The previous form did this wrong, which can also be seen because
the test still passes against current master of NetworkManager --
although it would be expected to fail. Fix it.

Fixes: e12de017e6668a48490490abdae0f660024bc51d

---

This is a follow up for #152, which got this wrong.

I tested it, it seems to work. I recommend to merge this patch right away (if you agree), but note that this test is supposed to fail with current master of NetworkManager. It already tests new behavior, that will be merge soon. That is fine.