### PR TITLE
Fix kernel-options mapper parameter

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -28,7 +28,7 @@ dependencies:
 beaker-hardware:
   - x86_64:
       group: desktopqe-nm
-      kernel_options: biosdevname=0 net.ifnames=0
+      kernel-options: biosdevname=0 net.ifnames=0
   - subcomponents:
       NetworkManager-wifi:
         - x86_64:


### PR DESCRIPTION
@RunTests:ethernet_create_with_editor,ethernet_create_default_connection,ethernet_create_ifname_generic_connection,ethernet_connection_up,ethernet_disconnect_device,ethernet_describe_all,ethernet_describe_separately,ethernet_set_matching_mac,no_assumed_connection_for_veth,ethernet_set_invalid_mac,ethernet_set_blacklisted_mac,ethernet_mac_spoofing,ethernet_mac_address_preserve,ethernet_mac_address_permanent,ethernet_mac_address_rhel7_default,ethernet_duplex_speed_auto_negotiation,ethernet_set_mtu,nmcli_set_mtu_lower_limit,ethernet_set_static_configuration,ethernet_set_static_ipv6_configuration,ethernet_set_both_ipv4_6_configuration,nmcli_ethernet_no_ip,nmcli_ethernet_wol_default,nmcli_ethernet_wol_enable_magic,nmcli_ethernet_wol_disable,nmcli_ethernet_wol_from_file,nmcli_ethernet_wol_from_file_to_default,8021x_with_credentials,8021x_tls,8021x_peap_md5,8021x_peap_mschapv2,8021x_peap_gtc,8021x_ttls_pap,8021x_ttls_chap,8021x_ttls_mschap,8021x_ttls_mschapv2,8021x_ttls_mschapv2_eap,8021x_ttls_md5,8021x_ttls_gtc,8021x_with_raw_credentials,8021x_without_password,8021x_without_password,8021x_without_password_with_ask_at_the_end,preserve_8021x_certs,preserve_8021x_leap_con