### PR TITLE
general: fix race in test setting zone in @show_zones_after_firewalld_install

### DIFF
--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -808,7 +808,7 @@ Feature: nmcli - general
     * Add a new connection of type "ethernet" and options "ifname eth8 con-name con_general connection.zone work"
     * Execute "yum -y install firewalld"
     * Execute "systemctl start firewalld"
-    Then "work" is visible with command "firewall-cmd  --get-zone-of-interface=eth8"
+    Then "work" is visible with command "firewall-cmd  --get-zone-of-interface=eth8" in "3" seconds
 
 
     @rhbz1286576


### PR DESCRIPTION
Recent failures:
(master, 30.03.2018) [master-upstream-576](https://desktopqe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/NetworkManager/job/beaker-NetworkManager-master-upstream/576/)
(pr#103, 24.04.2018) [master-upstream-608](https://desktopqe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/beaker-NetworkManager-github-trigger-code-upstream/608/)