### PR TITLE
ipv4: fix @dhcp-timeout_default_in_cfg test

### DIFF
--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1426,13 +1426,14 @@ Feature: nmcli: ipv4
     @con_ipv4_remove @remove_custom_cfg @teardown_testveth @restart
     @dhcp-timeout_default_in_cfg
     Scenario: nmcli - ipv4 - dhcp_timout infinity in cfg file
-    * Execute "echo -e '[connection-eth-dhcp-timeout]\nmatch-device=type:ethernet\nipv4.dhcp-timeout=2147483647' > /etc/NetworkManager/conf.d/99-xxcustom.conf"
+    * Execute "echo -e '[connection-eth-dhcp-timeout]\nmatch-device=type:ethernet;type:veth\nipv4.dhcp-timeout=2147483647' > /etc/NetworkManager/conf.d/99-xxcustom.conf"
     * Execute "systemctl reload NetworkManager"
     * Prepare simulated test "testX4" device
-    * Add connection type "ethernet" named "con_ipv4" for device "testX4"
+    * Add a new connection of type "ethernet" and options "ifname testX4 con-name con_ipv4 autoconnect no"
     * Execute "ip netns exec testX4_ns kill -SIGSTOP $(cat /tmp/testX4_ns.pid)"
     * Execute "sleep 50; ip netns exec testX4_ns kill -SIGCONT $(cat /tmp/testX4_ns.pid)" without waiting for process to finish
     * Restart NM
+    * Bring "up" connection "con_ipv4"
     Then "routers = 192.168.99.1" is visible with command "nmcli con show con_ipv4" in "180" seconds
      And "default via 192.168.99.1 dev testX4" is visible with command "ip r"
      And "IPV4_DHCP_TIMEOUT=2147483647" is not visible with command "cat /etc/sysconfig/network-scripts/ifcfg-con_ipv4"


### PR DESCRIPTION
Tests can run with veth devices instead of ethernet; therefore match
also veth device type in the configuration snippet.

While at it change the connection with autoconnect=no, and manually
activate it. Otherwise, we can't be sure that the test succeeds
because the inifinity timeout was honored; for example, it can happen
that DHCP fails after 45 seconds and autoconnection kicks in.