### PR TITLE
ipv4: make symlink checks better

### DIFF
--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -230,7 +230,8 @@ def before_scenario(context, scenario):
 
         if 'rhel7_only' in scenario.tags:
             if call('rpm -qi NetworkManager |grep -q build.*bos.redhat.co', shell=True) != 0 or \
-            check_output("rpm --queryformat %{RELEASE} -q NetworkManager |awk -F .  '{ print ($1 < 200) }'", shell=True).strip() == '0':
+            check_output("rpm --queryformat %{RELEASE} -q NetworkManager |awk -F .  '{ print ($1 < 200) }'", shell=True).strip() == '0' or \
+            call("grep -q Maipo /etc/redhat-release", shell=True) != 0:
                 sys.exit(0)
 
         if 'not_in_rhel' in scenario.tags:

--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -787,7 +787,7 @@ Feature: nmcli: ipv4
     Then "nameserver 8.8.8.8" is visible with command "cat /etc/resolv.conf" in "20" seconds
      And "nameserver 8.8.8.8" is visible with command "cat /var/run/NetworkManager/resolv.conf"
      And "are identical" is not visible with command "diff -s /tmp/resolv.conf /tmp/resolv_orig.conf"
-     And "/etc/resolv.conf: symbolic link to `/tmp/resolv.conf" is visible with command "file /etc/resolv.conf"
+     And "/etc/resolv.conf -> /tmp/resolv.conf" is visible with command "ls -all /etc/resolv.conf"
 
 
     @rhbz+=1423490
@@ -808,7 +808,7 @@ Feature: nmcli: ipv4
     Then "nameserver 8.8.8.8" is visible with command "cat /var/run/NetworkManager/resolv.conf"
      And "nameserver 8.8.8.8" is not visible with command "cat /etc/resolv.conf"
      And "are identical" is visible with command "diff -s /tmp/resolv.conf /tmp/resolv_orig.conf"
-     And "/etc/resolv.conf: symbolic link to `/tmp/resolv.conf" is visible with command "file /etc/resolv.conf"
+     And "/etc/resolv.conf -> /tmp/resolv.conf" is visible with command "ls -all /etc/resolv.conf"
 
 
     @rhbz+=1423490
@@ -828,7 +828,7 @@ Feature: nmcli: ipv4
     Then "nameserver 8.8.8.8" is visible with command "cat /etc/resolv.conf" in "20" seconds
      And "nameserver 8.8.8.8" is visible with command "cat /var/run/NetworkManager/resolv.conf"
      And "are identical" is not visible with command "diff -s /tmp/resolv.conf /tmp/resolv_orig.conf"
-     And "/etc/resolv.conf: symbolic link to `/tmp/resolv.conf" is visible with command "file /etc/resolv.conf"
+     And "/etc/resolv.conf -> /tmp/resolv.conf" is visible with command "ls -all /etc/resolv.conf"
 
 
     @con_ipv4_remove @eth0


### PR DESCRIPTION
and skip rhel7 only tests properly