### PR TITLE
steps: change ping to curl for systems wher ping is blocked

### DIFF
--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -1265,7 +1265,10 @@ def check_ifaces_in_state(context, exclude_ifaces, iface_state):
 @step(u'Ping "{domain}"')
 @step(u'Ping "{domain}" "{number}" times')
 def ping_domain(context, domain, number=2):
-    ping = pexpect.spawn('ping -4 -c %s %s' %(number, domain), logfile=context.log)
+    if number != 2:
+        ping = pexpect.spawn('ping -4 -c %s %s' %(number, domain), logfile=context.log)
+    else:
+        ping = pexpect.spawn('curl %s' %(domain), logfile=context.log)
     ping.expect([pexpect.EOF])
     ping.close()
     assert ping.exitstatus == 0
@@ -1859,7 +1862,7 @@ def terminate_spawned_process(context, command):
 
 @step(u'Unable to ping "{domain}"')
 def cannot_ping_domain(context, domain):
-    ping = pexpect.spawn('ping -c 2 %s' %domain, logfile=context.log)
+    ping = pexpect.spawn('curl %s' %domain, logfile=context.log)
     ping.expect([pexpect.EOF])
     ping.close()
     assert ping.exitstatus != 0


### PR DESCRIPTION
Often we see that in NATed environment ping is block and thus
few tests are not working as expected (e.g dns-search).