### PR TITLE
 bridge: add ipv6 bridge test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -22,7 +22,7 @@ dependencies:
   beaker-tasks:
     - /distribution/command:
         CMDS_TO_RUN: echo "NA"
-        
+
 beaker-hardware:
   - x86_64:
       group: desktopqe-nm
@@ -270,6 +270,8 @@ testmapper:
     - bridge_delete_connection_with_device:
         feature: bridge
     - bridge_delete_connection_without_device:
+        feature: bridge
+    - bridge_ipv6:
         feature: bridge
     - add_default_team:
         feature: team

--- a/nmcli/features/bridge.feature
+++ b/nmcli/features/bridge.feature
@@ -544,4 +544,5 @@ Feature: nmcli - bridge
     * Add a new connection of type "bridge" and options "con-name bridge0 ifname bridge0 ip4 172.16.3.1/24 ipv6.method auto ipv6.address fd01:42::1/64 bridge.forward-delay 5 autoconnect no"
     * Add a new connection of type "ethernet" and options "ifname eth4 con-name bridge-slave-eth4 master bridge0 autoconnect no"
     * Bring "up" connection "bridge-slave-eth4"
-    Then "fd01:42::1/64" is visible with command "ip a show dev bridge0" in "10" seconds
+    Then "fe80" is visible with command "ip a show dev bridge0" in "10" seconds
+     And "fd01:42::1/64" is visible with command "ip a show dev bridge0" in "10" seconds

--- a/nmcli/features/bridge.feature
+++ b/nmcli/features/bridge.feature
@@ -534,3 +534,14 @@ Feature: nmcli - bridge
     * Reboot
     * Delete connection "bridge0"
     Then "bridge0" is visible with command "nmcli dev"
+
+
+    @rhbz1576254
+    @ver+=1.10
+    @bridge
+    @bridge_ipv6
+    Scenario: nmcli - bridge - ipv6
+    * Add a new connection of type "bridge" and options "con-name bridge0 ifname bridge0 ip4 172.16.3.1/24 ipv6.method auto ipv6.address fd01:42::1/64 bridge.forward-delay 5 autoconnect no"
+    * Add a new connection of type "ethernet" and options "ifname eth4 con-name bridge-slave-eth4 master bridge0 autoconnect no"
+    * Bring "up" connection "bridge-slave-eth4"
+    Then "fd01:42::1/64" is visible with command "ip a show dev bridge0" in "10" seconds

--- a/run/osci/fedora28.tests
+++ b/run/osci/fedora28.tests
@@ -13,6 +13,7 @@ bridge_add_custom_one
 bridge_dhcp_config_with_multiple_ethernet_ports
 bridge_remove_slave
 bridge_delete_connection_with_device
+bridge_ipv6
 connection_down
 connection_permission_to_user
 connection_zone_drop_to_public


### PR DESCRIPTION
It looks we wasn't testing ipv6 on bridge at all. Adding a simple
test to exercise it.

@Build:nm-1-10