### PR TITLE
steps/env: check pid after every step to reveal crash

### DIFF
--- a/nmcli/features/bond.feature
+++ b/nmcli/features/bond.feature
@@ -1342,7 +1342,7 @@
     @bond @restart
     @delete_addrgenmode_bond
     Scenario: NM - bond - addrgenmode bond delete
-    * Execute "systemctl stop NetworkManager"
+    * Stop NM
     * Execute "ip l add bond0 type bond"
     * Execute "ip l set eth4 down; ip l set eth4 master bond0; ip l set eth4 addrgenmode none; ip l set eth4 up"
     * Execute "ip l set eth1 down; ip l set eth1 master bond0; ip l set eth1 addrgenmode none; ip l set eth1 up"
@@ -1463,7 +1463,7 @@
      And "eth1:connected:bond0.0" is visible with command "nmcli -t -f DEVICE,STATE,CONNECTION device"
      And "eth4:connected:bond0.1" is visible with command "nmcli -t -f DEVICE,STATE,CONNECTION device"
      And "nm-bond.153:connected:vlan" is visible with command "nmcli -t -f DEVICE,STATE,CONNECTION device"
-    * Execute "systemctl stop NetworkManager"
+    * Stop NM
     When "state UP" is visible with command "ip a s eth1"
      And "state UP" is visible with command "ip a s eth4"
      And "state UP" is visible with command "ip a s nm-bond"
@@ -1489,7 +1489,7 @@
       When "nm-bond:bond:connected:bond0" is visible with command "nmcli -t -f DEVICE,TYPE,STATE,CONNECTION device" in "20" seconds
        And "state UP" is visible with command "ip -6 a s nm-bond"
        And "inet6 fe80" is visible with command "ip -6 a s nm-bond"
-      * Execute "killall NetworkManager && sleep 5"
+      * Kill NM
       * Restart NM
       When "state UP" is visible with command "ip -6 a s nm-bond"
        And "inet6 fe80" is visible with command "ip -6 a s nm-bond" for full "10" seconds
@@ -1504,7 +1504,7 @@
     @bond @restart
     @bond_assume_options_1
     Scenario: nmcli - bond - assume options 1
-     * Execute "systemctl stop NetworkManager"
+     * Stop NM
      * Execute "ip l add bond0 type bond"
      * Execute "echo 1   > /sys/class/net/bond0/bonding/mode"
      * Execute "echo 100 > /sys/class/net/bond0/bonding/miimon"

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -1860,7 +1860,7 @@ def after_scenario(context, scenario):
 
         context.log.close ()
         context.embed('text/plain', open("/tmp/log_%s.html" % scenario.name, 'r').read())
-
+        sleep(3)
 
         if context.crashed_step:
             print ("\n\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
@@ -1876,5 +1876,3 @@ def after_scenario(context, scenario):
 
 def after_all(context):
     pass
-    #call('sudo kill $(ps aux|grep -v grep| grep /usr/bin/beah-beaker-backend |awk \'{print $2}\')', shell=True)
-    #Popen('beah-beaker-backend -H $(hostname) &', shell=True)

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1164,7 +1164,8 @@ Feature: nmcli - general
     * "connected:con_general" is visible with command "nmcli -t -f STATE,CONNECTION device" in "50" seconds
     * "connected:con_general2" is visible with command "nmcli -t -f STATE,CONNECTION device" in "50" seconds
     # Finish asserts the command exited with 0, thus the network service completed properly
-    Then Finish "systemctl restart NetworkManager.service && sleep 3 && systemctl restart network.service"
+    * Restart NM
+    Then Finish "sleep 3 && systemctl restart network.service"
 
 
     @rhbz1079353

--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -797,7 +797,7 @@ Feature: nmcli: ipv4
     Scenario: nmcli - ipv4 - dns - symlink
     * Bring "down" connection "testeth0"
     * Execute "echo -e '[main]\nrc-manager=symlink' > /etc/NetworkManager/conf.d/99-resolv.conf"
-    * Execute "systemctl restart NetworkManager"
+    * Restart NM
     When "activated" is visible with command "nmcli -g GENERAL.STATE con show testeth0" in "20" seconds
     * Execute "cp /etc/resolv.conf /tmp/resolv_orig.conf"
     * Execute "mv -f /etc/resolv.conf /tmp/resolv.conf"
@@ -818,7 +818,7 @@ Feature: nmcli: ipv4
     Scenario: nmcli - ipv4 - dns - file
     * Bring "down" connection "testeth0"
     * Execute "echo -e '[main]\nrc-manager=file' > /etc/NetworkManager/conf.d/99-resolv.conf"
-    * Execute "systemctl restart NetworkManager"
+    * Restart NM
     When "activated" is visible with command "nmcli -g GENERAL.STATE con show testeth0" in "20" seconds
     * Execute "cp /etc/resolv.conf /tmp/resolv_orig.conf"
     * Execute "mv -f /etc/resolv.conf /tmp/resolv.conf"
@@ -1548,11 +1548,11 @@ Feature: nmcli: ipv4
     * Execute "ip netns exec testX4_ns kill -SIGSTOP $(cat /tmp/testX4_ns.pid)"
     * Execute "ip netns exec testY4_ns kill -SIGSTOP $(cat /tmp/testY4_ns.pid)"
     ## STOP NM
-    * Execute "systemctl stop NetworkManager"
+    * Stop NM
     # REMOVE con_ipv4 ifcfg file
     * Execute "sudo rm -rf /etc/sysconfig/network-scripts/ifcfg-con_ipv4"
     ## RESTART NM AGAIN
-    * Execute "systemctl start NetworkManager"
+    * Start NM
 
     ################# PREPARE testZ4 AND testA4 ################################
     ## testA4 and con_ipv42 for renewal_gw_after_long_dhcp_outage

--- a/nmcli/features/ipv6.feature
+++ b/nmcli/features/ipv6.feature
@@ -1115,7 +1115,7 @@
     @ipv6_no_assumed_connection_for_ipv6ll_only
     Scenario: NM - ipv6 - no assumed connection on IPv6LL only device
     * Delete connection "testeth10"
-    * Execute "systemctl stop NetworkManager.service"
+    * Stop NM
     * Execute "ip a flush dev eth10; ip l set eth10 down; ip l set eth10 up"
     When "fe80" is visible with command "ip a s eth10" in "5" seconds
     * Execute "systemctl start NetworkManager.service"
@@ -1226,7 +1226,7 @@
     Scenario: NM - ipv6 - persistent default ipv6 gw
     * Add a new connection of type "ethernet" and options "ifname testX6 con-name con_ipv6"
     * Wait for at least "3" seconds
-    * Execute "systemctl stop NetworkManager"
+    * Stop NM
     * Prepare simulated test "testX6" device
     * Execute "sysctl net.ipv6.conf.testX6.accept_ra_defrtr=1"
     * Execute "sysctl net.ipv6.conf.testX6.accept_ra_pinfo=1"
@@ -1246,7 +1246,7 @@
     Scenario: NM - ipv6 - persistent default ipv6 gw
     * Add a new connection of type "ethernet" and options "ifname testX6 con-name con_ipv6"
     * Wait for at least "3" seconds
-    * Execute "systemctl stop NetworkManager"
+    * Stop NM
     * Prepare simulated test "testX6" device
     * Execute "sysctl net.ipv6.conf.testX6.accept_ra_defrtr=1"
     * Execute "sysctl net.ipv6.conf.testX6.accept_ra_pinfo=1"
@@ -1267,7 +1267,7 @@
     Scenario: NM - ipv6 - persistent default ipv6 gw
     * Add a new connection of type "ethernet" and options "ifname testX6 con-name con_ipv6"
     * Wait for at least "3" seconds
-    * Execute "systemctl stop NetworkManager"
+    * Stop NM
     * Prepare simulated test "testX6" device
     * Execute "sysctl net.ipv6.conf.testX6.accept_ra_defrtr=1"
     * Execute "sysctl net.ipv6.conf.testX6.accept_ra_pinfo=1"
@@ -1287,7 +1287,7 @@
     Scenario: NM - ipv6 - persistent ipv6 routes
     * Add a new connection of type "ethernet" and options "ifname testX6 con-name con_ipv6"
     * Wait for at least "3" seconds
-    * Execute "systemctl stop NetworkManager"
+    * Stop NM
     * Execute "rm -rf /var/run/NetworkManager"
     * Prepare simulated test "testX6" device
     * Execute "sysctl net.ipv6.conf.testX6.accept_ra_defrtr=1"

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -1618,6 +1618,10 @@ def restart_NM(context):
     # For stability reasons 1 is not enough, please do not lower this
     sleep(2)
 
+@step(u'Kill NM')
+def stop_NM(context):
+    context.nm_restarted = True
+    call("kill $(pidof NetworkManager) && sleep 5", shell=True)
 
 @step(u'Stop NM')
 def stop_NM(context):

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -287,6 +287,7 @@ def bring_down_connection_ignoring(context, connection):
 
 @step(u'Check ipv6 connectivity is stable on assuming connection profile "{profile}" for device "{device}"')
 def check_ipv6_connectivity_on_assumal(context, profile, device):
+    context.nm_restarted = True
     address = command_output(context, "ip -6 a s %s | grep dynamic | awk '{print $2; exit}' | cut -d '/' -f1" % device)
     assert command_code(context, 'systemctl stop NetworkManager.service') == 0
     assert command_code(context, "sed -i 's/UUID=/#UUID=/' /etc/sysconfig/network-scripts/ifcfg-%s" % profile)  == 0
@@ -1572,6 +1573,7 @@ def quit_editor(context):
 
 @step(u'Reboot')
 def reboot(context):
+    context.nm_restarted = True
     assert command_code(context, "sudo service NetworkManager stop") == 0
     for x in xrange(1,10):
         command_code(context, "sudo ip link set dev eth%d down" %int(x))
@@ -1583,7 +1585,6 @@ def reboot(context):
     command_code(context, "rm -rf /var/run/NetworkManager")
 
     sleep(3)
-    context.nm_restarted = True
     assert command_code(context, "sudo service NetworkManager start") == 0
     sleep(5)
 

--- a/nmcli/features/team.feature
+++ b/nmcli/features/team.feature
@@ -791,8 +791,8 @@
       And "inet6 fe80" is visible with command "ip -6 a s nm-team"
       And "inet6 2620" is visible with command "ip -6 a s nm-team" in "25" seconds
       And "tentative" is not visible with command "ip -6 a s nm-team" in "5" seconds
-     * Execute "killall NetworkManager && sleep 5"
-     * Execute "systemctl restart NetworkManager"
+     * Kill NM
+     * Restart NM
      When "state UP" is visible with command "ip -6 a s nm-team"
       And "inet6 fe80" is visible with command "ip -6 a s nm-team" for full "10" seconds
       And "inet6 2620" is visible with command "ip -6 a s nm-team"

--- a/nmcli/features/vlan.feature
+++ b/nmcli/features/vlan.feature
@@ -30,7 +30,7 @@ Feature: nmcli - vlan
     @restart @vlan
     @nmcli_vlan_restart_persistence
     Scenario: nmcli - vlan - restart persistence
-    * Execute "systemctl stop NetworkManager"
+    * Stop NM
     * Append "NAME=eth7.99" to ifcfg file "eth7.99"
     * Append "ONBOOT=yes" to ifcfg file "eth7.99"
     * Append "BOOTPROTO=none" to ifcfg file "eth7.99"
@@ -327,10 +327,10 @@ Feature: nmcli - vlan
     # Check all is up
     * "connected:vlan_bond7.7" is visible with command "nmcli -t -f STATE,CONNECTION device" in "5" seconds
     # Delete bridge and bond outside NM, leaving the vlan device (with its mac set)
-    * Finish "systemctl stop NetworkManager.service"
+    * Stop NM
     * Finish "ip link del bond7"
     * Finish "ip link del bridge7"
-    * Finish "systemctl start NetworkManager.service"
+    * Start NM
     # Check the configuration has been restored in full after by NM again
     Then "connected:vlan_bridge7" is visible with command "nmcli -t -f STATE,CONNECTION device" in "30" seconds
     Then "connected:vlan_vlan7" is visible with command "nmcli -t -f STATE,CONNECTION device"


### PR DESCRIPTION
We should stop test if PID was unexpectedly changed after it. This
should show us where crash happened.

@Build:master