### PR TITLE
ipv6: remove ip6_gre module in @ipv6_tunnel_module_removal test

### DIFF
--- a/nmcli/features/ipv6.feature
+++ b/nmcli/features/ipv6.feature
@@ -1189,6 +1189,7 @@
     Scenario: NM - ipv6 - ip6_tunnel module removal
     * Execute "modprobe ip6_tunnel"
     When "ip6_tunnel" is visible with command "lsmod |grep ip"
+    * Execute "modprobe -r ip6_gre"
     * Execute "modprobe -r ip6_tunnel"
     Then "ip6_tunnel" is not visible with command "lsmod |grep ip" in "2" seconds
 


### PR DESCRIPTION
If the ip6_gre and ip6_tunnel modules were already loaded before the
test, ip6_tunnel removal would fail because ip6_gre depends on it.