### PR TITLE
Set correct permissions for preshared keys

### DIFF
--- a/prepare/racoon.sh
+++ b/prepare/racoon.sh
@@ -84,6 +84,10 @@ function racoon_setup ()
     for i in {3..41}; do
         echo "172.31.70.$i ipsecret" >> $RACOON_DIR/psk.txt
     done
+    
+    # Set correct permissions for the file containing preshared keys.
+    # This is needed in RHEL 7.6 in order for work correctly.
+    chmod 600 $RACOON_DIR/psk.txt
 
     if getent passwd budulinek > /dev/null; then
         userdel -r budulinek


### PR DESCRIPTION
This is needed in RHEL 7.6 in order for work correctly.
Extract from the journal where an issue can be seen:
ERROR: /etc/racoon/psk.txt has weak file permission
ERROR: failed to open pre_share_key file /etc/racoon/psk.txt
Context: -rw-r--r-- 1 root root /etc/racoon/psk.txt
FIX:     -rw------- 1 root root /etc/racoon/psk.txt