### PR TITLE
Devel/fp/nm starts with incorrect logging config

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1082,6 +1082,8 @@ testmapper:
         feature: general
     - resolv_conf_overwrite_after_stop:
         feature: general
+    - NM_starts_with_incorrect_logging_config:
+        feature: general
     - openvswitch_interface_recognized:
         feature: ovs
     - openvswitch_ignore_ovs_network_setup:

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -942,6 +942,11 @@ def after_scenario(context, scenario):
             call("nmcli device disconnect eth10", shell=True)
             call("nmcli connection up testeth0", shell=True)
 
+        if 'remove_custom_cfg_before_restart' in scenario.tags:
+            print("---------------------------")
+            print("Removing custom cfg file in conf.d")
+            call('sudo rm -f /etc/NetworkManager/conf.d/99-xxcustom.conf', shell=True)
+
         if 'restart' in scenario.tags:
             print ("---------------------------")
             print ("restarting NM service")

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1690,3 +1690,13 @@ Feature: nmcli - general
     When "nameserver 1.2.3.4" is visible with command "cat /etc/resolv.conf"
     * Start NM
     Then "nameserver 1.2.3.4" is not visible with command "cat /etc/resolv.conf"
+
+
+    @rhbz1593519
+    @ver+=1.10
+    @remove_custom_cfg_before_restart @restart
+    @NM_starts_with_incorrect_logging_config
+    Scenario: NM - general - nm starts even when logging is incorrectly configured
+    * Stop NM
+    * Execute "echo -e '[logging]\nlevel=DEFAULT:WARN,TEAM:TRACE' > /etc/NetworkManager/conf.d/99-xxcustom.conf;"
+    Then Start NM

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1693,7 +1693,7 @@ Feature: nmcli - general
 
 
     @rhbz1593519
-    @ver+=1.10
+    @ver+=1.12
     @remove_custom_cfg_before_restart @restart
     @NM_starts_with_incorrect_logging_config
     Scenario: NM - general - nm starts even when logging is incorrectly configured


### PR DESCRIPTION
add 'NM_starts_with_incorrect_logging_config' test

Add check, that NM starts even if logging config is incorrect

https://bugzilla.redhat.com/show_bug.cgi?id=1593519

@Build:nm-1-12