### PR TITLE
 add 'resolv_conf_dangling_symlink' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1082,6 +1082,8 @@ testmapper:
         feature: general
     # - resolv_conf_overwrite_after_stop:
     #     feature: general
+    - resolv_conf_dangling_symlink:
+        feature: general
     - openvswitch_interface_recognized:
         feature: ovs
     - openvswitch_ignore_ovs_network_setup:

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1690,3 +1690,25 @@ Feature: nmcli - general
     When "nameserver 1.2.3.4" is visible with command "cat /etc/resolv.conf"
     * Start NM
     Then "nameserver 1.2.3.4" is not visible with command "cat /etc/resolv.conf"
+
+
+    @rhbz1593661
+    @ver+=1.12
+    @restart @remove_custom_cfg
+    @resolv_conf_dangling_symlink
+    Scenario: NM - general - follow resolv.conf when dangling symlink
+    * Stop NM
+    * Append "[main]" to file "/etc/NetworkManager/conf.d/99-xxcustom.conf"
+    * Append "rc-manager=file" to file "/etc/NetworkManager/conf.d/99-xxcustom.conf"
+    * Remove file "/etc/resolv.conf" if exists
+    * Remove file "/tmp/no-resolv.conf" if exists
+    * Create symlink "/etc/resolv.conf" with destination "/tmp/no-resolv.conf"
+    * Start NM
+    * Wait for at least "2" seconds
+    Then "/etc/resolv.conf" is symlink with destination "/tmp/no-resolv.conf"
+    * Stop NM
+    * Remove symlink "/etc/resolv.conf" if exists
+    * Wait for at least "2" seconds
+    * Start NM
+    Then "/tmp/no-resolv.conf" is file
+    * Remove file "/tmp/no-resolv.conf" if exists

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -2007,3 +2007,40 @@ def setup_macsec_psk(context, cak, ckn):
                                          --dhcp-range=172.16.10.10,172.16.10.254,60m  \
                                          --interface=macsec0 \
                                          --bind-interfaces")
+
+
+@step('"{filename}" is file')
+def is_file(context, filename):
+    assert os.path.isfile(filename), '"%s" is not a file' % filename
+    return True
+
+
+@step('"{filename}" is symlink')
+@step('"{filename}" is symlink with destination "{destination}"')
+def is_file(context, filename, destination=None):
+    assert os.path.islink(filename), '"%s" is not a symlink' % filename
+    realpath = os.path.realpath(filename)
+    if destination is None:
+        return True
+    assert realpath == destination, 'symlink "%s" has destination "%s" instead of "%s"' % (filename, realpath, destination)
+    return True
+
+
+@step('Remove file "{filename}" if exists')
+def remove_file(context, filename):
+    if os.path.isfile(filename):
+        os.remove(filename)
+    return True
+
+
+@step('Remove symlink "{filename}" if exists')
+def remove_file(context, filename):
+    if os.path.islink(filename):
+        os.remove(filename)
+    return True
+
+
+@step('Create symlink {source} with destination {destination}')
+def create_symlink(context, source, destination):
+    cmd = 'sudo ln -s "%s" "%s"' % (destination, source)
+    command_code(context, cmd)


### PR DESCRIPTION
Add check, that if resolv.conf is dangling symlink,
it will be followed and new file will be created,
when main.rc-manager=file in config

Add new steps:
    "{filename}" is file
    "{filename}" is symlink
    "{filename}" is symlink with destination "{destination}"
    Remove file "{filename}" if exists
    Remove symlink "{filename}" if exists
    Create symlink {source} with destination {destination}

@Build:nm-1-12