### PR TITLE
FIX: unstable tests

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -736,8 +736,8 @@ testmapper:
         feature: ipv4
     - ipv4_multiple_ip4:
         feature: ipv4
-    # - ipv4_dhcp-hostname_shared_persists:
-    #     feature: ipv4
+    - ipv4_dhcp-hostname_shared_persists:
+        feature: ipv4
     - vlan_add_default_device:
         feature: vlan
     - vlan_add_beyond_range:
@@ -1084,8 +1084,8 @@ testmapper:
         feature: general
     - NM_starts_with_incorrect_logging_config:
         feature: general
-    # - resolv_conf_overwrite_after_stop:
-    #     feature: general
+    - resolv_conf_overwrite_after_stop:
+        feature: general
     - macsec_send-sci_by_default:
         feature: general
     - openvswitch_interface_recognized:

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1683,14 +1683,16 @@ Feature: nmcli - general
    
     @rhbz1541031
     @ver+=1.12
-    @restart
+    @restart @remove_custom_cfg
     @resolv_conf_overwrite_after_stop
     Scenario: NM - general - overwrite resolv conf after stop
-    * Execute "echo 'nameserver 1.2.3.4' >> /etc/resolv.conf"
+    * Append "[main]" to file "/etc/NetworkManager/conf.d/99-xxcustom.conf"
+    * Append "rc-manager=unmanaged" to file "/etc/NetworkManager/conf.d/99-xxcustom.conf"
+    * Append "nameserver 1.2.3.4" to file "/etc/resolv.conf"
     * Stop NM
-    When "nameserver 1.2.3.4" is visible with command "cat /etc/resolv.conf"
+    When "nameserver 1.2.3.4" is visible with command "cat /etc/resolv.conf" in "3" seconds
     * Start NM
-    Then "nameserver 1.2.3.4" is not visible with command "cat /etc/resolv.conf"
+    Then "nameserver 1.2.3.4" is visible with command "cat /etc/resolv.conf" in "3" seconds
 
 
     @rhbz1593519

--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1989,7 +1989,7 @@ Feature: nmcli: ipv4
     
 
     @rhbz1519299
-    @ver+=1.10.4
+    @ver+=1.12
     @con_ipv4_remove
     @ipv4_dhcp-hostname_shared_persists
     Scenario: nmcli - ipv4 - ipv4 dhcp-hostname persists after method shared set


### PR DESCRIPTION
"ipv4_dhcp-hostname_shared_persists" and "resolv_conf_overwrite_after_stop"

fix versions, add timeouts after NM restarts

@Build:nm-1-12