### PR TITLE
add "tuntap_device_kernel_properties" test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1286,6 +1286,8 @@ testmapper:
         feature: tuntap
     - preserve_master_and_ip_settings:
         feature: tuntap
+    - tuntap_device_kernel_properties:
+        feature: tuntap
     - set_fq_codel_queue:
         feature: tc
     - set_pfifo_fast_queue:

--- a/nmcli/features/tuntap.feature
+++ b/nmcli/features/tuntap.feature
@@ -70,3 +70,26 @@ Feature: nmcli: tuntap
      When "master" is visible with command "ip link show tap0" in "2" seconds
       And "192.0.2.2\/24" is visible with command "ip a s tap0" in "2" seconds
       And "tap0:connected:tap0" is not visible with command "nmcli -t -f DEVICE,STATE,CONNECTION device" in "10" seconds
+    
+    @rhbz1547213
+    @tuntap
+    @ver+=1.12.0
+    @tuntap_device_kernel_properties
+    Scenario: nmcli - tuntap - test tuntap properties from kernel, dbus, nmcli
+    * Add a new connection of type "tun" and options "ifname tap0 con-name tap0 tun.mode 1 ipv4.addresses 1.2.3.4/24 ipv4.method manual"
+    When "tap0:connected:tap0" is visible with command "nmcli -t -f DEVICE,STATE,CONNECTION device" in "10" seconds
+    Then Finish "bash tmp/tuntap_device_kernel_properties.sh tap0 owner"
+     And Finish "bash tmp/tuntap_device_kernel_properties.sh tap0 group"
+     And Finish "bash tmp/tuntap_device_kernel_properties.sh tap0 mode tun"
+     And Finish "bash tmp/tuntap_device_kernel_properties.sh tap0 multi-queue"
+     And Finish "bash tmp/tuntap_device_kernel_properties.sh tap0 vnet-hdr"
+     And Finish "bash tmp/tuntap_device_kernel_properties.sh tap0 nopi"
+    * Modify connection "tap0" changing options "tun.mode 2 tun.pi yes tun.vnet-hdr yes tun.multi-queue no tun.owner 1000 tun.group 1002"
+    * Bring "down" connection "tap0"
+    * Bring "up" connection "tap0"
+    Then Finish "bash tmp/tuntap_device_kernel_properties.sh tap0 owner 1000"
+     And Finish "bash tmp/tuntap_device_kernel_properties.sh tap0 group 1002"
+     And Finish "bash tmp/tuntap_device_kernel_properties.sh tap0 mode tap"
+     And Finish "bash tmp/tuntap_device_kernel_properties.sh tap0 multi-queue false"
+     And Finish "bash tmp/tuntap_device_kernel_properties.sh tap0 vnet-hdr true"
+     And Finish "bash tmp/tuntap_device_kernel_properties.sh tap0 nopi false"

--- a/tmp/tuntap_device_kernel_properties.sh
+++ b/tmp/tuntap_device_kernel_properties.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# gathers tuntap device properties from kernel, dbus and nmcli an compares them
+# USAGE: tmp/tuntap_device_kernel_properties.sh {device} {property} [expected value]
+# supported properties:
+#   owner:       numeric id of tuntap device owner, -1 if undefined
+#   gourp:       numeric id of tuntap device group, -1 if undefined
+#   mode:        tun or tap
+#   nopi:        true or false
+#   multi-queue: true or false
+#   vnet-hder:   true or false
+#
+###############################################################################
+
+FLAG_NOPI=0x1000
+FLAG_MULTIQUEUE=0x100
+FLAG_VNETHDR=0x4000
+
+# test binary flag and convert it to boolean
+apply_flag() {
+    n1=$1
+    n2=$2
+    r=$((n1 & n2))
+    if [ "x$r" == "x0" ]; then
+        echo "false"
+    else
+        echo "true"
+    fi
+}
+
+# get response from nm and unify results
+parse_nm_line() {
+    arg=$(echo "$@" | awk '{print $2}')
+    if [ "x$arg" == "x--" ]; then
+        arg=-1
+    elif [ "x$arg" == "xno" ]; then
+        arg=false
+    elif [ "x$arg" == "xyes" ]; then
+        arg=true
+    fi
+    echo $arg
+}
+
+negate() {
+    if [ "x$1" == "xtrue" ]; then
+        echo false
+    else
+        echo true
+    fi
+}
+
+# send dbus query and unify result (ignore type - first column and delete quotes)
+query_dbus() {
+    busctl get-property org.freedesktop.NetworkManager "$DBUS_PATH" org.freedesktop.NetworkManager.Device.Tun $1 | awk '{print $2}' | sed 's/"//g' 
+}
+
+# read property from sysfs
+get_sysfs() {
+    if [ "x$prop" == "xowner" ]; then
+        cat "${SYS_PATH}${prop}"
+    elif [ "x$prop" == "xgroup" ]; then
+        cat "${SYS_PATH}${prop}"
+    elif [ "x$prop" == "xmode" ]; then
+        t=$(cat "${SYS_PATH}type")
+        if [ "x$t" == "x1" ]; then
+            echo "tap"
+        elif [ "x$t" == "x65534" ]; then
+            echo "tun"
+        else
+            echo "error"
+        fi
+    elif [ "x$prop" == "xnopi" ]; then
+        flags=$(cat "${SYS_PATH}tun_flags")
+        apply_flag $flags $FLAG_NOPI
+    elif [ "x$prop" == "xmulti-queue" ]; then
+        flags=$(cat "${SYS_PATH}tun_flags")
+        apply_flag $flags $FLAG_MULTIQUEUE
+    elif [ "x$prop" == "xvnet-hdr" ]; then
+        flags=$(cat "${SYS_PATH}tun_flags")
+        apply_flag $flags $FLAG_VNETHDR
+    fi
+}
+
+# read property from nmcli
+get_nmcli() {
+    if [ "x$prop" == "xowner" ]; then
+        parse_nm_line $(nmcli -f tun.$prop con show $dev)
+    elif [ "x$prop" == "xgroup" ]; then
+        parse_nm_line $(nmcli -f tun.$prop con show $dev)
+    elif [ "x$prop" == "xmode" ]; then
+        t=$(parse_nm_line $(nmcli -f tun.$prop con show $dev))
+        if [ "x$t" == "x2" ]; then
+            echo "tap"
+        elif [ "x$t" == "x1" ]; then
+            echo "tun"
+        else
+            echo "error"
+        fi
+    elif [ "x$prop" == "xnopi" ]; then
+        # nmcli has pi instead of nopi
+        negate $(parse_nm_line $(nmcli -f tun.pi con show $dev))
+    elif [ "x$prop" == "xmulti-queue" ]; then
+        parse_nm_line $(nmcli -f tun.$prop con show $dev)
+    elif [ "x$prop" == "xvnet-hdr" ]; then
+        parse_nm_line $(nmcli -f tun.$prop con show $dev)
+    fi
+}
+
+# read property from nmcli dbus
+get_dbus() {
+    if [ "x$prop" == "xowner" ]; then
+        query_dbus Owner
+    elif [ "x$prop" == "xgroup" ]; then
+        query_dbus Group
+    elif [ "x$prop" == "xmode" ]; then
+        query_dbus Mode
+    elif [ "x$prop" == "xnopi" ]; then
+        query_dbus NoPi
+    elif [ "x$prop" == "xmulti-queue" ]; then
+        query_dbus MultiQueue
+    elif [ "x$prop" == "xvnet-hdr" ]; then
+        query_dbus VnetHdr
+    fi
+}
+
+
+###################################################################
+
+# set arguments
+dev=$1
+prop=$2
+exp=$3
+
+# set paths
+DBUS_PATH="$(nmcli -f DEVICE,DBUS-PATH -t device | sed -n "s/^$dev://p")";
+SYS_PATH=/sys/devices/virtual/net/$dev/
+
+# get values
+sys=$(get_sysfs)
+nmcli=$(get_nmcli)
+dbus=$(get_dbus)
+
+# if no expected result provided, set it to $sys
+if [ -z "$exp" ]; then
+    exp=$sys
+fi
+
+# all equal
+if [ "x$sys" != "x$nmcli" ] || [ "x$sys" != "x$dbus" ]; then
+    >&2 echo "ERROR: not equal values"
+    echo "sys: $sys nmcli: $nmcli dbus: $dbus expected: $exp"
+    exit 1
+# all empty means bad property specified
+elif [ -z "$sys" ]; then
+    >&2 echo "ERROR: empty response of all (wron property?)"
+    exit 1
+# compare to expected result, comparing $sys to $sys if no expectated result provided
+elif [ "x$sys" != "x$exp" ]; then
+    >&2 echo "ERROR: not expected value"
+    echo "sys=nmcli=dbus: $sys expected: $exp"
+    exit 1
+else 
+    echo OK
+    exit 0
+fi


### PR DESCRIPTION
Add test, that kernel, dbus and nmcli returns the same properties of tuntap device

https://bugzilla.redhat.com/show_bug.cgi?id=1547213

@Build:nm-1-12