### PR TITLE
python 2 and 3 compatibility

### DIFF
--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -358,7 +358,7 @@ def before_scenario(context, scenario):
         if 'allow_veth_connections' in scenario.tags:
             if call("grep '^ENV{ID_NET_DRIVER}==\"veth\", ENV{NM_UNMANAGED}=\"1\"' /usr/lib/udev/rules.d/85-nm-unmanaged.rules", shell=True) == 0:
                 call("sed -i 's/^ENV{ID_NET_DRIVER}==\"veth\", ENV{NM_UNMANAGED}=\"1\"/#ENV{ID_NET_DRIVER}==\"veth\", ENV{NM_UNMANAGED}=\"1\"/' /usr/lib/udev/rules.d/85-nm-unmanaged.rules", shell=True)
-                cfg = Popen("sudo sh -c 'cat > /etc/NetworkManager/conf.d/99-unmanaged.conf'", stdin=PIPE, shell=True).stdin
+                cfg = open("/etc/NetworkManager/conf.d/99-unmanaged.conf", "w")
                 cfg.write('[main]')
                 cfg.write("\n" + 'no-auto-default=eth*')
                 cfg.write("\n")
@@ -605,7 +605,7 @@ def before_scenario(context, scenario):
             sleep(2)
 
             samples = glob(os.path.abspath('tmp/openvpn'))[0]
-            cfg = Popen("sudo sh -c 'cat >/etc/openvpn/trest-server.conf'", stdin=PIPE, shell=True).stdin
+            cfg = open("/etc/openvpn/trest-server.conf'", "w")
             cfg.write('# OpenVPN configuration for client testing')
             cfg.write("\n" + 'mode server')
             cfg.write("\n" + 'tls-server')
@@ -681,12 +681,12 @@ def before_scenario(context, scenario):
             call("rpm -q NetworkManager-pptp || sudo yum -y install NetworkManager-pptp", shell=True)
 
             call("sudo rm -f /etc/ppp/ppp-secrets", shell=True)
-            psk = Popen("sudo sh -c 'cat >/etc/ppp/chap-secrets'", stdin=PIPE, shell=True).stdin
+            psk = open("/etc/ppp/chap-secrets", "w")
             psk.write("budulinek pptpd passwd *\n")
             psk.close()
 
             if not os.path.isfile('/tmp/nm_pptp_configured'):
-                cfg = Popen("sudo sh -c 'cat >/etc/pptpd.conf'", stdin=PIPE, shell=True).stdin
+                cfg = open("/etc/pptpd.conf", "w")
                 cfg.write('# pptpd configuration for client testing')
                 cfg.write("\n" + 'option /etc/ppp/options.pptpd')
                 cfg.write("\n" + 'logwtmp')

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -77,7 +77,7 @@ def reset_usb_devices():
     USBDEVFS_RESET= 21780
     def getfile(dirname, filename):
         f = open("%s/%s" % (dirname, filename), "r")
-        contents = f.read().encode('utf-8'))
+        contents = f.read().encode('utf-8')
         f.close()
         return contents
 
@@ -905,7 +905,7 @@ def after_scenario(context, scenario):
         #attach network traffic log
         call("sudo kill -1 $(pidof tcpdump)", shell=True)
         if os.stat("/tmp/network-traffic.log").st_size < 20000000:
-            traffic = open("/tmp/network-traffic.log", 'r').read().encode('utf-8'))
+            traffic = open("/tmp/network-traffic.log", 'r').read()
             if traffic:
                 context.embed('text/plain', traffic)
         else:
@@ -916,7 +916,7 @@ def after_scenario(context, scenario):
             # Attach network.service journalctl logs
             os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ NETWORK SRV LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/journal-netsrv.log")
             os.system("sudo journalctl -u network --no-pager -o cat %s >> /tmp/journal-netsrv.log" % context.log_cursor)
-            data = open("/tmp/journal-netsrv.log", 'r').read().encode('utf-8'))
+            data = open("/tmp/journal-netsrv.log", 'r').read()
             if data:
                 context.embed('text/plain', data)
 
@@ -1392,14 +1392,14 @@ def after_scenario(context, scenario):
         if "attach_hostapd_log" in scenario.tags:
             os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ HOSTAPD LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/journal-hostapd.log")
             os.system("sudo journalctl -u nm-hostapd --no-pager -o cat %s >> /tmp/journal-hostapd.log" % context.log_cursor)
-            data = open("/tmp/journal-hostapd.log", 'r').read().encode('utf-8'))
+            data = open("/tmp/journal-hostapd.log", 'r').read()
             if data:
                 context.embed('text/plain', data)
 
         if "attach_wpa_supplicant_log" in scenario.tags:
             os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ WPA_SUPPLICANT LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/journal-wpa_supplicant.log")
             os.system("journalctl -u wpa_supplicant --no-pager -o cat %s >> /tmp/journal-wpa_supplicant.log" % context.log_cursor)
-            data = open("/tmp/journal-wpa_supplicant.log", 'r').read().encode('utf-8'))
+            data = open("/tmp/journal-wpa_supplicant.log", 'r').read()
             if data:
                 context.embed('text/plain', data)
 
@@ -1675,7 +1675,7 @@ def after_scenario(context, scenario):
             # Attach journalctl logs
             os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ MM LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/journal-mm.log")
             os.system("sudo journalctl -u ModemManager --no-pager -o cat %s >> /tmp/journal-mm.log" % context.log_cursor)
-            data = open("/tmp/journal-mm.log", 'r').read().encode('utf-8'))
+            data = open("/tmp/journal-mm.log", 'r').read()
             if data:
                 context.embed('text/plain', data)
 
@@ -1872,7 +1872,7 @@ def after_scenario(context, scenario):
         os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ NM LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/journal-nm.log")
         os.system("sudo journalctl -u NetworkManager --no-pager -o cat %s >> /tmp/journal-nm.log" % context.log_cursor)
         if os.stat("/tmp/journal-nm.log").st_size < 20000000:
-            data = open("/tmp/journal-nm.log", 'r').read().encode('utf-8')
+            data = open("/tmp/journal-nm.log", 'r').read()
             if data:
                 context.embed('text/plain', data)
         else:
@@ -1886,7 +1886,7 @@ def after_scenario(context, scenario):
                 call("LOGNAME=root HOSTNAME=localhost gdb /usr/sbin/NetworkManager -ex 'target remote | vgdb' -ex 'monitor leak_check full kinds all increased' -batch", shell=True, stdout=context.log, stderr=context.log)
 
         context.log.close ()
-        context.embed('text/plain', open("/tmp/log_%s.html" % scenario.name, 'r').read().encode('utf-8')))
+        context.embed('text/plain', open("/tmp/log_%s.html" % scenario.name, 'r').read())
         sleep(3)
 
         if context.crashed_step:

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -605,7 +605,7 @@ def before_scenario(context, scenario):
             sleep(2)
 
             samples = glob(os.path.abspath('tmp/openvpn'))[0]
-            cfg = open("/etc/openvpn/trest-server.conf'", "w")
+            cfg = open("/etc/openvpn/trest-server.conf", "w")
             cfg.write('# OpenVPN configuration for client testing')
             cfg.write("\n" + 'mode server')
             cfg.write("\n" + 'tls-server')

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -4,8 +4,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 import pexpect
 import sys
-reload(sys)
-sys.setdefaultencoding('utf8')
+if sys.version_info < (3, 0):
+    reload(sys)
+    sys.setdefaultencoding('utf8')
 
 import traceback
 import string
@@ -76,7 +77,7 @@ def reset_usb_devices():
     USBDEVFS_RESET= 21780
     def getfile(dirname, filename):
         f = open("%s/%s" % (dirname, filename), "r")
-        contents = f.read()
+        contents = f.read().encode('utf-8'))
         f.close()
         return contents
 
@@ -904,7 +905,7 @@ def after_scenario(context, scenario):
         #attach network traffic log
         call("sudo kill -1 $(pidof tcpdump)", shell=True)
         if os.stat("/tmp/network-traffic.log").st_size < 20000000:
-            traffic = open("/tmp/network-traffic.log", 'r').read()
+            traffic = open("/tmp/network-traffic.log", 'r').read().encode('utf-8'))
             if traffic:
                 context.embed('text/plain', traffic)
         else:
@@ -915,7 +916,7 @@ def after_scenario(context, scenario):
             # Attach network.service journalctl logs
             os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ NETWORK SRV LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/journal-netsrv.log")
             os.system("sudo journalctl -u network --no-pager -o cat %s >> /tmp/journal-netsrv.log" % context.log_cursor)
-            data = open("/tmp/journal-netsrv.log", 'r').read()
+            data = open("/tmp/journal-netsrv.log", 'r').read().encode('utf-8'))
             if data:
                 context.embed('text/plain', data)
 
@@ -1391,14 +1392,14 @@ def after_scenario(context, scenario):
         if "attach_hostapd_log" in scenario.tags:
             os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ HOSTAPD LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/journal-hostapd.log")
             os.system("sudo journalctl -u nm-hostapd --no-pager -o cat %s >> /tmp/journal-hostapd.log" % context.log_cursor)
-            data = open("/tmp/journal-hostapd.log", 'r').read()
+            data = open("/tmp/journal-hostapd.log", 'r').read().encode('utf-8'))
             if data:
                 context.embed('text/plain', data)
 
         if "attach_wpa_supplicant_log" in scenario.tags:
             os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ WPA_SUPPLICANT LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/journal-wpa_supplicant.log")
             os.system("journalctl -u wpa_supplicant --no-pager -o cat %s >> /tmp/journal-wpa_supplicant.log" % context.log_cursor)
-            data = open("/tmp/journal-wpa_supplicant.log", 'r').read()
+            data = open("/tmp/journal-wpa_supplicant.log", 'r').read().encode('utf-8'))
             if data:
                 context.embed('text/plain', data)
 
@@ -1674,7 +1675,7 @@ def after_scenario(context, scenario):
             # Attach journalctl logs
             os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ MM LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/journal-mm.log")
             os.system("sudo journalctl -u ModemManager --no-pager -o cat %s >> /tmp/journal-mm.log" % context.log_cursor)
-            data = open("/tmp/journal-mm.log", 'r').read()
+            data = open("/tmp/journal-mm.log", 'r').read().encode('utf-8'))
             if data:
                 context.embed('text/plain', data)
 
@@ -1885,7 +1886,7 @@ def after_scenario(context, scenario):
                 call("LOGNAME=root HOSTNAME=localhost gdb /usr/sbin/NetworkManager -ex 'target remote | vgdb' -ex 'monitor leak_check full kinds all increased' -batch", shell=True, stdout=context.log, stderr=context.log)
 
         context.log.close ()
-        context.embed('text/plain', open("/tmp/log_%s.html" % scenario.name, 'r').read())
+        context.embed('text/plain', open("/tmp/log_%s.html" % scenario.name, 'r').read().encode('utf-8')))
         sleep(3)
 
         if context.crashed_step:

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -1,8 +1,12 @@
 # -*- coding: UTF-8 -*-
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import pexpect
 import sys
+reload(sys)
+sys.setdefaultencoding('utf8')
+
 import traceback
 import string
 import fcntl
@@ -1755,6 +1759,7 @@ def after_scenario(context, scenario):
         if 'non_utf_device' in scenario.tags:
             print ("---------------------------")
             print ("remove non utf-8 device")
+            call("nmcli device delete 'd\\314f\\\\c'", shell=True)
             call("ip link del $'d\xccf\\c'", shell=True)
             call('systemctl restart NetworkManager', shell=True)
 
@@ -1866,7 +1871,7 @@ def after_scenario(context, scenario):
         os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ NM LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/journal-nm.log")
         os.system("sudo journalctl -u NetworkManager --no-pager -o cat %s >> /tmp/journal-nm.log" % context.log_cursor)
         if os.stat("/tmp/journal-nm.log").st_size < 20000000:
-            data = open("/tmp/journal-nm.log", 'r').read()
+            data = open("/tmp/journal-nm.log", 'r').read().encode('utf-8')
             if data:
                 context.embed('text/plain', data)
         else:

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1561,7 +1561,7 @@ Feature: nmcli - general
     * Execute "ip link add name $'d\xccf\\c' type dummy"
     When "/sys/devices/virtual/net/d\\314f\\\\c" is visible with command "nmcli -f GENERAL.UDI device show"
     * Restart NM
-    Then "dummy" is visible with command "nmcli device show 'd\314f\\c'"
+    Then "dummy" is visible with command "nmcli device show d\\314f\\\\c"
 
 
     @rhbz1458399

--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1957,9 +1957,9 @@ Feature: nmcli: ipv4
     * Execute "ip link add AAA type dummy"
     * Execute "ip link set dev AAA up"
     * Execute "for i in $(seq 20); do for j in $(seq 200); do ip addr add 10.3.$i.$j/16 dev AAA; done; done"
-    Then "4000" is visible with command "ip addr show dev AAA | grep 'inet 10.3.' -c"
+    Then "4000" is visible with command "ip addr show dev AAA | grep "inet 10.3." -c"
     * Execute "sleep 6"
-    Then "4000" is visible with command "ip addr show dev AAA | grep 'inet 10.3.' -c"
+    Then "4000" is visible with command "ip addr show dev AAA | grep "inet 10.3." -c"
 
 
     @rhbz1428334
@@ -1986,7 +1986,7 @@ Feature: nmcli: ipv4
     * Bring "up" connection "con_ipv4"
     Then "192.168.124.1/24" is visible with command "ip a s eth3"
     Then "192.168.125.1/24" is visible with command "ip a s eth3"
-    
+
 
     @rhbz1519299
     @ver+=1.12

--- a/nmcli/features/ovs.feature
+++ b/nmcli/features/ovs.feature
@@ -22,6 +22,7 @@ Feature: nmcli - ovs
 
 
     @ver+=1.10
+    @rhel7_only
     @openvswitch
     @openvswitch_ignore_ovs_network_setup
     Scenario: NM - openvswitch - ignore ovs network setup
@@ -41,6 +42,7 @@ Feature: nmcli - ovs
 
 
     @ver+=1.10
+    @rhel7_only
     @openvswitch
     @openvswitch_ignore_ovs_vlan_network_setup
     Scenario: NM - openvswitch - ignore ovs network setup
@@ -56,6 +58,7 @@ Feature: nmcli - ovs
 
 
     @ver+=1.10
+    @rhel7_only
     @openvswitch
     @openvswitch_ignore_ovs_bond_network_setup
     Scenario: NM - openvswitch - ignore ovs network setup

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -13,7 +13,7 @@ from glob import glob
 
 def run(context, command, *a, **kw):
     try:
-        output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT, *a, **kw)
+        output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT, *a, **kw).decode('utf-8')
         returncode = 0
         exception = None
     except subprocess.CalledProcessError as e:

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -1148,7 +1148,7 @@ def check_pattern_visible_with_command(context, pattern, command):
     proc = pexpect.spawn(cmd, maxread=100000, logfile=context.log, encoding='utf-8')
     if proc.expect([pattern, pexpect.EOF]) != 0:
         sleep(1)
-        proc = pexpect.spawn(cmd, maxread=100000, logfile=context.log, encoding='utf-8')
+        proc = pexpect.spawn(cmd,  encoding='utf-8', maxread=100000, logfile=context.log)
         assert proc.expect([pattern, pexpect.EOF]) == 0, 'pattern %s is not visible with %s' % (pattern, command)
     else:
         return True
@@ -1203,7 +1203,7 @@ def check_pattern_not_visible_with_command_in_time(context, pattern, command, se
     seconds = int(seconds)
     orig_seconds = seconds
     while seconds > 0:
-        proc = pexpect.spawn(cmd.encode('utf-8'), timeout = 180, logfile=context.log, encoding='utf-8')
+        proc = pexpect.spawn(cmd, timeout = 180, logfile=context.log, encoding='utf-8')
         if proc.expect([pattern, pexpect.EOF]) != 0:
             return True
         seconds = seconds - 1

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -17,7 +17,7 @@ def run(context, command, *a, **kw):
         returncode = 0
         exception = None
     except subprocess.CalledProcessError as e:
-        output = e.output
+        output = str(e.output)
         returncode = e.returncode
         exception = e
     context.embed('text/plain', '$?=%d' % returncode, caption='%s result' % command)
@@ -1552,7 +1552,7 @@ def prompt_is_not_running(context):
     sleep(0.2)
     if context.prompt.pid:
         prompt = False
-        for x in xrange(1,4):
+        for x in range(1,4):
             prompt = context.prompt.isalive()
             if not prompt:
                 break
@@ -1576,7 +1576,7 @@ def quit_editor(context):
 def reboot(context):
     context.nm_restarted = True
     assert command_code(context, "sudo service NetworkManager stop") == 0
-    for x in xrange(1,10):
+    for x in range(1,10):
         command_code(context, "sudo ip link set dev eth%d down" %int(x))
         command_code(context, "sudo ip addr flush dev eth%d" %int(x))
 

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -1,9 +1,9 @@
 # -*- coding: UTF-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
 from behave import step
 from time import sleep, time
 import pexpect
 import os
-import exceptions
 import re
 import subprocess
 from subprocess import Popen, check_output, call
@@ -41,7 +41,7 @@ def do_device_stuff(context, action, what):
 
 @step(u'Activate connection')
 def activate_connection(context):
-    prompt = pexpect.spawn('activate')
+    prompt = pexpect.spawn('activate', encoding='utf-8')
     context.prompt = prompt
 
 
@@ -59,7 +59,7 @@ def append_to_ifcfg(context, line, name):
 
 # @step(u'Add connection for a type "{typ}" named "{name}"')
 # def add_connection(context, typ, name):
-#     cli = pexpect.spawn('nmcli connection add type %s con-name %s' % (typ, name), logfile=context.log)
+#     cli = pexpect.spawn('nmcli connection add type %s con-name %s' % (typ, name), logfile=context.log, encoding='utf-8')
 #     r = cli.expect(['Error', pexpect.EOF])
 #     if r == 0:
 #         raise Exception('Got an Error while adding %s connection %s' % (typ, name))
@@ -67,7 +67,7 @@ def append_to_ifcfg(context, line, name):
 
 @step(u'Add a connection named "{name}" for device "{ifname}" to "{vpn}" VPN')
 def add_vpnc_connection_for_iface(context, name, ifname, vpn):
-    cli = pexpect.spawn('nmcli connection add con-name %s type vpn ifname %s vpn-type %s' % (name, ifname, vpn), logfile=context.log)
+    cli = pexpect.spawn('nmcli connection add con-name %s type vpn ifname %s vpn-type %s' % (name, ifname, vpn), logfile=context.log, encoding='utf-8')
     r = cli.expect(['Error', pexpect.EOF])
     sleep(1)
     if r == 0:
@@ -86,7 +86,7 @@ def add_secondary_addr_same_subnet(context, device):
 @given(u'Use certificate "{cert}" with key "{key}" and authority "{ca}" for gateway "{gateway}" on OpenVPN connection "{name}"')
 def set_openvpn_connection(context, cert, key, ca, gateway, name):
     samples = glob(os.path.abspath('tmp/openvpn/'))[0]+'/'
-    cli = pexpect.spawn('nmcli c modify %s vpn.data "tunnel-mtu = 1400, key = %s, connection-type = tls, ca = %s, cert = %s, remote = %s, cert-pass-flags = 0"' % (name, samples + key, samples + ca, samples + cert, gateway))
+    cli = pexpect.spawn('nmcli c modify %s vpn.data "tunnel-mtu = 1400, key = %s, connection-type = tls, ca = %s, cert = %s, remote = %s, cert-pass-flags = 0"' % (name, samples + key, samples + ca, samples + cert, gateway), encoding='utf-8')
     r = cli.expect(['Error', pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while editing %s connection data' % (name))
@@ -94,7 +94,7 @@ def set_openvpn_connection(context, cert, key, ca, gateway, name):
 
 @step(u'Add connection type "{typ}" named "{name}" for device "{ifname}"')
 def add_connection_for_iface(context, typ, name, ifname):
-    cli = pexpect.spawn('nmcli connection add type %s con-name %s ifname %s' % (typ, name, ifname), logfile=context.log)
+    cli = pexpect.spawn('nmcli connection add type %s con-name %s ifname %s' % (typ, name, ifname), logfile=context.log, encoding='utf-8')
     r = cli.expect(['Error', pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while adding %s connection %s for device %s' % (typ, name, ifname))
@@ -107,13 +107,13 @@ def add_new_default_connection(context, typ, ifname, options):
 
 @step(u'Add a new connection of type "{typ}" and options "{options}"')
 def add_new_default_connection_without_ifname(context, typ, options):
-    cli = pexpect.spawn('nmcli connection add type %s %s' % (typ, options), logfile=context.log)
+    cli = pexpect.spawn('nmcli connection add type %s %s' % (typ, options), logfile=context.log, encoding='utf-8')
     if cli.expect(['Error', pexpect.TIMEOUT, pexpect.EOF]) == 0:
         raise Exception('Got an Error while creating connection of type %s with options %s' % (typ,options))
 
 @step(u'Add infiniband port named "{name}" for device "{ifname}" with parent "{parent}" and p-key "{pkey}"')
 def add_port(context, name, ifname, parent, pkey):
-    cli = pexpect.spawn('nmcli connection add type infiniband con-name %s ifname %s parent %s p-key %s' % (name, ifname, parent, pkey), logfile=context.log)
+    cli = pexpect.spawn('nmcli connection add type infiniband con-name %s ifname %s parent %s p-key %s' % (name, ifname, parent, pkey), logfile=context.log, encoding='utf-8')
     r = cli.expect(['Error', pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while adding %s connection %s for device %s' % (typ, name, ifname))
@@ -121,7 +121,7 @@ def add_port(context, name, ifname, parent, pkey):
 
 @step(u'Modify connection "{connection}" property "{prop}" to noted value')
 def modify_connection_with_noted(context, connection, prop):
-    cli = pexpect.spawn('nmcli connection modify %s %s %s' % (connection, prop, context.noted_value))
+    cli = pexpect.spawn('nmcli connection modify %s %s %s' % (connection, prop, context.noted_value), encoding='utf-8')
     r = cli.expect(['Error', pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while changing %s property for connection %s to %s' % (prop, connection, context.noted_value))
@@ -129,10 +129,10 @@ def modify_connection_with_noted(context, connection, prop):
 @step(u'Add slave connection for master "{master}" on device "{device}" named "{name}"')
 def open_slave_connection(context, master, device, name):
     if master.find("team") != -1:
-        cli = pexpect.spawn('nmcli connection add type team-slave ifname %s con-name %s master %s' % (device, name, master), logfile=context.log)
+        cli = pexpect.spawn('nmcli connection add type team-slave ifname %s con-name %s master %s' % (device, name, master), logfile=context.log, encoding='utf-8')
         r = cli.expect(['Error', pexpect.EOF])
     if master.find("bond") != -1:
-        cli = pexpect.spawn('nmcli connection add type bond-slave ifname %s con-name %s master %s' % (device, name, master), logfile=context.log)
+        cli = pexpect.spawn('nmcli connection add type bond-slave ifname %s con-name %s master %s' % (device, name, master), logfile=context.log, encoding='utf-8')
         r = cli.expect(['Error', pexpect.EOF])
 
     if r == 0:
@@ -142,16 +142,16 @@ def open_slave_connection(context, master, device, name):
 @step(u'Use user "{user}" with password "{password}" and group "{group}" with secret "{secret}" for gateway "{gateway}" on Libreswan connection "{name}"')
 def set_libreswan_connection(context, user, password, group, secret, gateway, name):
     if password == "ask" and secret != "ask":
-        cli = pexpect.spawn('nmcli c modify %s vpn.data "leftxauthusername = %s, leftid = %s, pskinputmodes = save, right = %s, xauthpasswordinputmodes = ask, pskvalue-flags = 0, xauthpassword-flags = 2, vendor = Cisco" vpn.secrets "pskvalue = %s"' % (name, user, group, gateway, secret))
+        cli = pexpect.spawn('nmcli c modify %s vpn.data "leftxauthusername = %s, leftid = %s, pskinputmodes = save, right = %s, xauthpasswordinputmodes = ask, pskvalue-flags = 0, xauthpassword-flags = 2, vendor = Cisco" vpn.secrets "pskvalue = %s"' % (name, user, group, gateway, secret), encoding='utf-8')
     if password == "ask" and secret == "ask":
-        cli = pexpect.spawn('nmcli c modify %s vpn.data "leftxauthusername = %s, leftid = %s, pskinputmodes = ask, right = %s, xauthpasswordinputmodes = ask, pskvalue-flags = 2, xauthpassword-flags = 2, vendor = Cisco"' % (name, user, group, gateway))
+        cli = pexpect.spawn('nmcli c modify %s vpn.data "leftxauthusername = %s, leftid = %s, pskinputmodes = ask, right = %s, xauthpasswordinputmodes = ask, pskvalue-flags = 2, xauthpassword-flags = 2, vendor = Cisco"' % (name, user, group, gateway), encoding='utf-8')
     if password != "ask" and secret == "ask":
-        cli = pexpect.spawn('nmcli c modify %s vpn.data "leftxauthusername = %s, leftid = %s, pskinputmodes = ask, right = %s, xauthpasswordinputmodes = save, pskvalue-flags = 2, xauthpassword-flags = 0, vendor = Cisco" vpn.secrets "xauthpassword = %s"' % (name, user, group, gateway))
+        cli = pexpect.spawn('nmcli c modify %s vpn.data "leftxauthusername = %s, leftid = %s, pskinputmodes = ask, right = %s, xauthpasswordinputmodes = save, pskvalue-flags = 2, xauthpassword-flags = 0, vendor = Cisco" vpn.secrets "xauthpassword = %s"' % (name, user, group, gateway), encoding='utf-8')
     if password != "ask" and secret != "ask":
         if group == 'Main':
-            cli = pexpect.spawn('nmcli c modify %s vpn.data "leftxauthusername = %s, pskinputmodes = save, right = %s, xauthpasswordinputmodes = save, pskvalue-flags = 0, xauthpassword-flags = 0, vendor = Cisco" vpn.secrets "pskvalue = %s, xauthpassword = %s"' % (name, user, gateway, secret, password))
+            cli = pexpect.spawn('nmcli c modify %s vpn.data "leftxauthusername = %s, pskinputmodes = save, right = %s, xauthpasswordinputmodes = save, pskvalue-flags = 0, xauthpassword-flags = 0, vendor = Cisco" vpn.secrets "pskvalue = %s, xauthpassword = %s"' % (name, user, gateway, secret, password), encoding='utf-8')
         else:
-            cli = pexpect.spawn('nmcli c modify %s vpn.data "leftxauthusername = %s, leftid = %s, pskinputmodes = save, right = %s, xauthpasswordinputmodes = save, pskvalue-flags = 0, xauthpassword-flags = 0, vendor = Cisco" vpn.secrets "pskvalue = %s, xauthpassword = %s"' % (name, user, group, gateway, secret, password))
+            cli = pexpect.spawn('nmcli c modify %s vpn.data "leftxauthusername = %s, leftid = %s, pskinputmodes = save, right = %s, xauthpasswordinputmodes = save, pskvalue-flags = 0, xauthpassword-flags = 0, vendor = Cisco" vpn.secrets "pskvalue = %s, xauthpassword = %s"' % (name, user, group, gateway, secret, password), encoding='utf-8')
 
     r = cli.expect(['Error', pexpect.EOF])
     if r == 0:
@@ -160,12 +160,12 @@ def set_libreswan_connection(context, user, password, group, secret, gateway, na
 
 @step(u'Use user "{user}" with password "{password}" and group "{group}" with secret "{secret}" for gateway "{gateway}" on VPNC connection "{name}"')
 def set_vpnc_connection(context, user, password, group, secret, gateway, name):
-    cli = pexpect.spawn('nmcli c modify %s vpn.data "NAT Traversal Mode=natt, ipsec-secret-type=save, IPSec secret-flags=0, xauth-password-type=save, Vendor=cisco, Xauth username=%s, IPSec gateway=%s, Xauth password-flags=0, IPSec ID=%s, Perfect Forward Secrecy=server, IKE DH Group=dh2, Local Port=0"' % (name, user, gateway, group))
+    cli = pexpect.spawn('nmcli c modify %s vpn.data "NAT Traversal Mode=natt, ipsec-secret-type=save, IPSec secret-flags=0, xauth-password-type=save, Vendor=cisco, Xauth username=%s, IPSec gateway=%s, Xauth password-flags=0, IPSec ID=%s, Perfect Forward Secrecy=server, IKE DH Group=dh2, Local Port=0"' % (name, user, gateway, group), encoding='utf-8')
     r = cli.expect(['Error', pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while editing %s connection data' % (name))
     sleep(1)
-    cli = pexpect.spawn('nmcli c modify %s vpn.secrets "IPSec secret=%s, Xauth password=%s"' % (name, secret, password))
+    cli = pexpect.spawn('nmcli c modify %s vpn.secrets "IPSec secret=%s, Xauth password=%s"' % (name, secret, password), encoding='utf-8')
     r = cli.expect(['Error', pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while editing %s connection secrets' % (name))
@@ -173,12 +173,12 @@ def set_vpnc_connection(context, user, password, group, secret, gateway, name):
 
 @step(u'Use user "{user}" with password "{password}" and MPPE set to "{mppe}" for gateway "{gateway}" on PPTP connection "{name}"')
 def set_vpnc_connection(context, user, password, mppe, gateway, name):
-    cli = pexpect.spawn('nmcli c modify %s vpn.data "password-flags = 0, user = %s, require-mppe = %s, gateway = %s"' % (name, user, mppe, gateway))
+    cli = pexpect.spawn('nmcli c modify %s vpn.data "password-flags = 0, user = %s, require-mppe = %s, gateway = %s"' % (name, user, mppe, gateway), encoding='utf-8')
     r = cli.expect(['Error', pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while editing %s connection data' % (name))
     sleep(2)
-    cli = pexpect.spawn('nmcli c modify %s vpn.secrets "password = %s"' % (name, password))
+    cli = pexpect.spawn('nmcli c modify %s vpn.secrets "password = %s"' % (name, password), encoding='utf-8')
     r = cli.expect(['Error', pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while editing %s connection secrets' % (name))
@@ -186,7 +186,7 @@ def set_vpnc_connection(context, user, password, mppe, gateway, name):
 
 @step(u'Autocomplete "{cmd}" in bash and execute')
 def autocomplete_command(context, cmd):
-    bash = pexpect.spawn("bash")
+    bash = pexpect.spawn("bash", encoding='utf-8')
     bash.send(cmd)
     bash.send('\t')
     sleep(1)
@@ -224,7 +224,7 @@ def start_stop_connection(context, action, name):
             print ("Warning: Connection is down no need to down it again")
             return
 
-    cli = pexpect.spawn('nmcli connection %s id %s' % (action, name), logfile=context.log,  timeout=180)
+    cli = pexpect.spawn('nmcli connection %s id %s' % (action, name), logfile=context.log,  timeout=180, encoding='utf-8')
 
     r = cli.expect(['Error', 'Timeout', pexpect.TIMEOUT, pexpect.EOF])
     if r == 0:
@@ -237,7 +237,7 @@ def start_stop_connection(context, action, name):
 
 @step(u'Bring up connection "{name}" for "{device}" device')
 def start_connection_for_device(context, name, device):
-    cli = pexpect.spawn('nmcli connection up id %s ifname %s' % (name, device), logfile=context.log,  timeout=180)
+    cli = pexpect.spawn('nmcli connection up id %s ifname %s' % (name, device), logfile=context.log,  timeout=180, encoding='utf-8')
     r = cli.expect(['Error', 'Timeout', pexpect.TIMEOUT, pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while uping connection %s on %s' % (name, device))
@@ -250,7 +250,7 @@ def start_connection_for_device(context, name, device):
 
 @step(u'Bring up connection "{connection}"')
 def bring_up_connection(context, connection):
-    cli = pexpect.spawn('nmcli connection up %s' % connection, timeout = 180, logfile=context.log)
+    cli = pexpect.spawn('nmcli connection up %s' % connection, timeout = 180, logfile=context.log, encoding='utf-8')
     r = cli.expect(['Error', pexpect.TIMEOUT, pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while upping connection %s' % connection)
@@ -260,7 +260,7 @@ def bring_up_connection(context, connection):
 
 @step(u'Bring up connection "{connection}" ignoring error')
 def bring_up_connection_ignore_error(context, connection):
-    cli = pexpect.spawn('nmcli connection up %s' % connection, timeout = 180, logfile=context.log)
+    cli = pexpect.spawn('nmcli connection up %s' % connection, timeout = 180, logfile=context.log, encoding='utf-8')
     r = cli.expect([pexpect.EOF, pexpect.TIMEOUT])
     if r == 1:
         raise Exception('nmcli connection up %s timed out (180s)' % connection)
@@ -269,7 +269,7 @@ def bring_up_connection_ignore_error(context, connection):
 
 @step(u'Bring down connection "{connection}"')
 def bring_down_connection(context, connection):
-    cli = pexpect.spawn('nmcli connection down %s' % connection, timeout = 180, logfile=context.log)
+    cli = pexpect.spawn('nmcli connection down %s' % connection, timeout = 180, logfile=context.log, encoding='utf-8')
     r = cli.expect(['Error', pexpect.TIMEOUT, pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while downing a connection %s' % connection)
@@ -279,7 +279,7 @@ def bring_down_connection(context, connection):
 
 @step(u'Bring down connection "{connection}" ignoring error')
 def bring_down_connection_ignoring(context, connection):
-    cli = pexpect.spawn('nmcli connection down %s' % connection, timeout = 180, logfile=context.log)
+    cli = pexpect.spawn('nmcli connection down %s' % connection, timeout = 180, logfile=context.log, encoding='utf-8')
     r = cli.expect([pexpect.EOF, pexpect.TIMEOUT])
     if r == 1:
         raise Exception('nmcli connection down %s timed out (180s)' % connection)
@@ -291,7 +291,7 @@ def check_ipv6_connectivity_on_assumal(context, profile, device):
     address = command_output(context, "ip -6 a s %s | grep dynamic | awk '{print $2; exit}' | cut -d '/' -f1" % device)
     assert command_code(context, 'systemctl stop NetworkManager.service') == 0
     assert command_code(context, "sed -i 's/UUID=/#UUID=/' /etc/sysconfig/network-scripts/ifcfg-%s" % profile)  == 0
-    ping = pexpect.spawn('ping6 %s -i 0.2 -c 50' % address, logfile=context.log)
+    ping = pexpect.spawn('ping6 %s -i 0.2 -c 50' % address, logfile=context.log, encoding='utf-8')
     sleep(1)
     assert command_code(context, 'systemctl start NetworkManager.service') == 0
     sleep(12)
@@ -399,7 +399,7 @@ def value_printed(context, item, value):
 
 @step(u'Check if "{name}" is active connection')
 def is_active_connection(context, name):
-    cli = pexpect.spawn('nmcli -t -f NAME connection show --active', logfile=context.log)
+    cli = pexpect.spawn('nmcli -t -f NAME connection show --active', logfile=context.log, encoding='utf-8')
     r = cli.expect([name,pexpect.EOF])
     if r == 1:
         raise Exception('Connection %s is not active' % name)
@@ -407,7 +407,7 @@ def is_active_connection(context, name):
 
 @step(u'Check if "{name}" is not active connection')
 def is_nonactive_connection(context, name):
-    cli = pexpect.spawn('nmcli -t -f NAME connection show --active', logfile=context.log)
+    cli = pexpect.spawn('nmcli -t -f NAME connection show --active', logfile=context.log, encoding='utf-8')
     r = cli.expect([name,pexpect.EOF])
     if r == 0:
         raise Exception('Connection %s is active' % name)
@@ -415,13 +415,13 @@ def is_nonactive_connection(context, name):
 
 @step(u'Check ifcfg-name file created with noted connection name')
 def check_ifcfg_exists(context):
-    cat = pexpect.spawn('cat /etc/sysconfig/network-scripts/ifcfg-%s' % context.noted, logfile=context.log)
+    cat = pexpect.spawn('cat /etc/sysconfig/network-scripts/ifcfg-%s' % context.noted, logfile=context.log, encoding='utf-8')
     cat.expect('NAME=%s' % context.noted)
 
 
 @step(u'Check ifcfg-name file created for connection "{con_name}"')
 def check_ifcfg_exists_given_device(context, con_name):
-    cat = pexpect.spawn('cat /etc/sysconfig/network-scripts/ifcfg-%s' % con_name, logfile=context.log)
+    cat = pexpect.spawn('cat /etc/sysconfig/network-scripts/ifcfg-%s' % con_name, logfile=context.log, encoding='utf-8')
     cat.expect('NAME=%s' % con_name)
 
 
@@ -440,16 +440,16 @@ def band_cap_set_if_supported(context, flag, device='wlan0'):
 
 @step(u'Check bond "{bond}" in proc')
 def check_bond_in_proc(context, bond):
-    child = pexpect.spawn('cat /proc/net/bonding/%s ' % (bond) , logfile=context.log)
+    child = pexpect.spawn('cat /proc/net/bonding/%s ' % (bond) , logfile=context.log, encoding='utf-8')
     assert child.expect(['Ethernet Channel Bonding Driver', pexpect.EOF]) == 0; "%s is not in proc" % bond
 
 
 @step(u'Check slave "{slave}" in bond "{bond}" in proc')
 def check_slave_in_bond_in_proc(context, slave, bond):
-    child = pexpect.spawn('cat /proc/net/bonding/%s' % (bond), logfile=context.log )
+    child = pexpect.spawn('cat /proc/net/bonding/%s' % (bond), logfile=context.log, encoding='utf-8')
     if child.expect(["Slave Interface: %s\s+MII Status: up" % slave, pexpect.EOF]) != 0:
         sleep(1)
-        child = pexpect.spawn('cat /proc/net/bonding/%s' % (bond), logfile=context.log )
+        child = pexpect.spawn('cat /proc/net/bonding/%s' % (bond), logfile=context.log, encoding='utf-8')
         assert child.expect(["Slave Interface: %s\s+MII Status: up" % slave, pexpect.EOF]) == 0, "Slave %s is not in %s" % (slave, bond)
     else:
         return True
@@ -466,7 +466,7 @@ def check_slave_in_team_is_up(context, slave, team, state):
         if r == 0:
             raise Exception('Device %s was found in dump of team %s' % (slave, team))
 
-    # child = pexpect.spawn('sudo teamdctl %s state dump' % (team),  maxread=10000, logfile=context.log )
+    # child = pexpect.spawn('sudo teamdctl %s state dump' % (team),  maxread=10000, logfile=context.log, encoding='utf-8')
     # if state == "up":
     #     found = '"ifname"\:\s+"%s"' % slave
     #     r = child.expect([found, 'Timeout', pexpect.TIMEOUT, pexpect.EOF])
@@ -488,18 +488,18 @@ def check_slave_present_in_bond_in_proc(context, slave, bond):
     # DON'T USE THIS STEP UNLESS YOU HAVE A GOOD REASON!!
     # this is not looking for up state as arp connections are sometimes down.
     # it's always better to check whether slave is up
-    child = pexpect.spawn('cat /proc/net/bonding/%s' % (bond), logfile=context.log )
+    child = pexpect.spawn('cat /proc/net/bonding/%s' % (bond), logfile=context.log, encoding='utf-8')
     assert child.expect(["Slave Interface: %s\s+MII Status:" % slave, pexpect.EOF]) == 0, "Slave %s is not in %s" % (slave, bond)
 
 
 @step(u'Check slave "{slave}" not in bond "{bond}" in proc')
 def check_slave_not_in_bond_in_proc(context, slave, bond):
-    child = pexpect.spawn('cat /proc/net/bonding/%s' % (bond), logfile=context.log )
+    child = pexpect.spawn('cat /proc/net/bonding/%s' % (bond), logfile=context.log, encoding='utf-8')
     assert child.expect(["Slave Interface: %s\s+MII Status: up" % slave, pexpect.EOF]) != 0, "Slave %s is in %s" % (slave, bond)
 
 @step(u'Check bond "{bond}" state is "{state}"')
 def check_bond_state(context, bond, state):
-    child = pexpect.spawn('ip addr show dev %s up' % (bond))
+    child = pexpect.spawn('ip addr show dev %s up' % (bond), encoding='utf-8')
     exp = 0 if state == "up" else 1
     r = child.expect(["\\d+: %s:" %  bond, pexpect.EOF])
     assert r == exp, "%s not in %s state" % (bond, state)
@@ -511,7 +511,7 @@ def check_bond_link_state(context, bond, state):
         return
     i = 4
     while i > 0:
-        child = pexpect.spawn('cat /proc/net/bonding/%s' % (bond))
+        child = pexpect.spawn('cat /proc/net/bonding/%s' % (bond), encoding='utf-8')
         if child.expect(["MII Status: %s" %  state, pexpect.EOF]) == 0:
             return
         else:
@@ -717,7 +717,7 @@ def compare_devices(context):
 
 @step(u'Connect device "{device}"')
 def connect_device(context, device):
-    cli = pexpect.spawn('nmcli device con %s' % device, timeout = 180, logfile=context.log)
+    cli = pexpect.spawn('nmcli device con %s' % device, timeout = 180, logfile=context.log, encoding='utf-8')
     r = cli.expect(['Error', pexpect.TIMEOUT, pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while connecting a device %s' % device)
@@ -727,7 +727,7 @@ def connect_device(context, device):
 
 @step(u'Connect wifi device to "{network}" network')
 def connect_wifi_device(context, network):
-    cli = pexpect.spawn('nmcli device wifi connect "%s"' % network, timeout = 180, logfile=context.log)
+    cli = pexpect.spawn('nmcli device wifi connect "%s"' % network, timeout = 180, logfile=context.log, encoding='utf-8')
     r = cli.expect(['Error', pexpect.TIMEOUT, pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while connecting to network %s' % network)
@@ -737,7 +737,7 @@ def connect_wifi_device(context, network):
 
 @step(u'Connect wifi device to "{network}" network with options "{options}"')
 def connect_wifi_device_w_options(context, network, options):
-    cli = pexpect.spawn('nmcli device wifi connect "%s" %s' % (network, options), timeout = 180, logfile=context.log)
+    cli = pexpect.spawn('nmcli device wifi connect "%s" %s' % (network, options), timeout = 180, logfile=context.log, encoding='utf-8')
     r = cli.expect(['Error', pexpect.TIMEOUT, pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while connecting to network %s' % network)
@@ -748,7 +748,7 @@ def connect_wifi_device_w_options(context, network, options):
 @step(u'Connect to vpn "{vpn}" with password "{password}" with timeout "{time_out}"')
 @step(u'Connect to vpn "{vpn}" with password "{password}" and secret "{secret}"')
 def connect_to_vpn(context, vpn, password, secret=None, time_out=None):
-    cli = pexpect.spawn('nmcli -a connect up %s' % (vpn), timeout = 180, logfile=context.log)
+    cli = pexpect.spawn('nmcli -a connect up %s' % (vpn), timeout = 180, logfile=context.log, encoding='utf-8')
     if not time_out:
         sleep(1)
     else:
@@ -765,7 +765,7 @@ def connect_to_vpn(context, vpn, password, secret=None, time_out=None):
 
 @step(u'Delete connection "{connection}"')
 def delete_connection(context,connection):
-    cli = pexpect.spawn('nmcli connection delete %s' % connection, timeout = 95, logfile=context.log)
+    cli = pexpect.spawn('nmcli connection delete %s' % connection, timeout = 95, logfile=context.log, encoding='utf-8')
     res = cli.expect(['Error', pexpect.TIMEOUT, pexpect.EOF])
     if res == 0:
         raise Exception('Got an Error while deleting connection %s' % connection)
@@ -784,7 +784,7 @@ def delete_connection_with_enter(context, name):
 
 @step(u'Disconnect device "{name}"')
 def disconnect_connection(context, name):
-    cli = pexpect.spawn('nmcli device disconnect %s' % name, logfile=context.log,  timeout=180)
+    cli = pexpect.spawn('nmcli device disconnect %s' % name, logfile=context.log,  timeout=180, encoding='utf-8')
 
     r = cli.expect(['Error', pexpect.TIMEOUT, pexpect.EOF])
     if r == 0:
@@ -857,7 +857,7 @@ def external_bridge_check(context, number):
 
 @step(u'Fail up connection "{name}" for "{device}"')
 def fail_up_connection_for_device(context, name, device):
-    cli = pexpect.spawn('nmcli connection up id %s ifname %s' % (name, device), logfile=context.log,  timeout=180)
+    cli = pexpect.spawn('nmcli connection up id %s ifname %s' % (name, device), logfile=context.log,  timeout=180, encoding='utf-8')
     r = cli.expect(['Error', 'Timeout', pexpect.TIMEOUT, pexpect.EOF])
     if r == 3:
         raise Exception('nmcli connection up %s for device %s was succesfull. this should not happen' % (name, device))
@@ -968,7 +968,7 @@ def hostname_visible(context, log):
 
 @step(u'ifcfg-"{con_name}" file does not exist')
 def ifcfg_doesnt_exist(context, con_name):
-    cat = pexpect.spawn('cat /etc/sysconfig/network-scripts/ifcfg-%s' % con_name, logfile=context.log)
+    cat = pexpect.spawn('cat /etc/sysconfig/network-scripts/ifcfg-%s' % con_name, logfile=context.log, encoding='utf-8')
     assert cat.expect('No such file') == 0, 'Ifcfg-%s exists!' % con_name
 
 
@@ -1007,7 +1007,7 @@ def mode_missing_in_editor(context):
 
 @step(u'Modify connection "{name}" changing options "{options}"')
 def modify_connection(context, name, options):
-    cli = pexpect.spawn('nmcli connection modify %s %s' % (name, options), logfile=context.log)
+    cli = pexpect.spawn('nmcli connection modify %s %s' % (name, options), logfile=context.log, encoding='utf-8')
     if cli.expect(['Error', pexpect.TIMEOUT, pexpect.EOF]) == 0:
         raise Exception('Got an Error while modifying %s options %s' % (name,options))
 
@@ -1058,7 +1058,7 @@ def note_print_property(context, prop):
 
 @step(u'Note the "{prop}" property from ifconfig output for device "{device}"')
 def note_print_property(context, prop, device):
-    ifc = pexpect.spawn('ifconfig %s' % device, logfile=context.log)
+    ifc = pexpect.spawn('ifconfig %s' % device, logfile=context.log, encoding='utf-8')
     ifc.expect('%s\s(\S+)' % prop)
     context.noted = ifc.match.group(1)
     print (context.noted)
@@ -1087,7 +1087,7 @@ def note_the_output_of(context, command):
 @step(u'Open editor for connection "{con_name}"')
 def open_editor_for_connection(context, con_name):
     sleep(0.2)
-    prompt = pexpect.spawn('/bin/nmcli connection ed %s' % con_name, logfile=context.log)
+    prompt = pexpect.spawn('/bin/nmcli connection ed %s' % con_name, logfile=context.log, encoding='utf-8')
     context.prompt = prompt
     r = prompt.expect([con_name, 'Error'])
     if r == 1:
@@ -1096,7 +1096,7 @@ def open_editor_for_connection(context, con_name):
 
 @step(u'Open editor for "{con_name}" with timeout')
 def open_editor_for_connection_with_timeout(context, con_name):
-    prompt = pexpect.spawn('nmcli connection ed %s' % (con_name), logfile=context.log, maxread=6000, timeout=5)
+    prompt = pexpect.spawn('nmcli connection ed %s' % (con_name), logfile=context.log, maxread=6000, timeout=5, encoding='utf-8')
     sleep(2)
     context.prompt = prompt
     r = prompt.expect(['Error', con_name])
@@ -1106,7 +1106,7 @@ def open_editor_for_connection_with_timeout(context, con_name):
 
 @step(u'Open editor for new connection "{con_name}" type "{type}"')
 def open_editor_for_connection_type(context, con_name, type):
-    prompt = pexpect.spawn('nmcli connection ed type %s con-name %s' % (type, con_name), logfile=context.log, maxread=6000)
+    prompt = pexpect.spawn('nmcli connection ed type %s con-name %s' % (type, con_name), logfile=context.log, maxread=6000, encoding='utf-8')
     context.prompt = prompt
     sleep(1)
     r = prompt.expect(['nmcli interactive connection editor','Error'])
@@ -1115,40 +1115,40 @@ def open_editor_for_connection_type(context, con_name, type):
 
 @step(u'Open editor for a new connection')
 def open_editor_for_new_connection(context):
-    prompt = pexpect.spawn('nmcli connection edit', logfile=context.log)
+    prompt = pexpect.spawn('nmcli connection edit', logfile=context.log, encoding='utf-8')
     context.prompt = prompt
 
 @step(u'Open editor for a type "{typ}"')
 def open_editor_for_a_type(context, typ):
-    prompt = pexpect.spawn('nmcli connection edit type %s con-name %s0' % (typ, typ), logfile=context.log)
+    prompt = pexpect.spawn('nmcli connection edit type %s con-name %s0' % (typ, typ), logfile=context.log, encoding='utf-8')
     context.prompt = prompt
 
 
 @step(u'Open interactive connection addition mode for a type "{typ}"')
 def open_interactive_for_a_type(context, typ):
-    prompt = pexpect.spawn('nmcli -a connection add type %s' % typ, timeout = 5, logfile=context.log)
+    prompt = pexpect.spawn('nmcli -a connection add type %s' % typ, timeout = 5, logfile=context.log, encoding='utf-8')
     context.prompt = prompt
 
 
 @step(u'Open interactive connection addition mode')
 def open_interactive(context):
-    prompt = pexpect.spawn('nmcli -a connection add', timeout = 5, logfile=context.log)
+    prompt = pexpect.spawn('nmcli -a connection add', timeout = 5, logfile=context.log, encoding='utf-8')
     context.prompt = prompt
 
 
 @step(u'Open wizard for adding new connection')
 def add_novice_connection(context):
-    prompt = pexpect.spawn("nmcli -a connection add", logfile=context.log)
+    prompt = pexpect.spawn("nmcli -a connection add", logfile=context.log, encoding='utf-8')
     context.prompt = prompt
 
 
 @step(u'"{pattern}" is visible with command "{command}"')
 def check_pattern_visible_with_command(context, pattern, command):
     cmd = '/bin/bash -c "%s"' %command
-    proc = pexpect.spawn(cmd, maxread=100000, logfile=context.log)
+    proc = pexpect.spawn(cmd, maxread=100000, logfile=context.log, encoding='utf-8')
     if proc.expect([pattern, pexpect.EOF]) != 0:
         sleep(1)
-        proc = pexpect.spawn(cmd, maxread=100000, logfile=context.log)
+        proc = pexpect.spawn(cmd, maxread=100000, logfile=context.log, encoding='utf-8')
         assert proc.expect([pattern, pexpect.EOF]) == 0, 'pattern %s is not visible with %s' % (pattern, command)
     else:
         return True
@@ -1159,7 +1159,7 @@ def check_pattern_visible_with_command_in_time(context, pattern, command, second
     seconds = int(seconds)
     orig_seconds = seconds
     while seconds > 0:
-        proc = pexpect.spawn(cmd, timeout = 180, logfile=context.log)
+        proc = pexpect.spawn(cmd, timeout = 180, logfile=context.log, encoding='utf-8')
         if proc.expect([pattern, pexpect.EOF]) == 0:
             return True
         seconds = seconds - 1
@@ -1173,7 +1173,7 @@ def check_pattern_visible_with_command_fortime(context, pattern, command, second
     seconds = int(seconds)
     orig_seconds = seconds
     while seconds > 0:
-        proc = pexpect.spawn(cmd, timeout = 180, logfile=context.log)
+        proc = pexpect.spawn(cmd, timeout = 180, logfile=context.log, encoding='utf-8')
         if proc.expect([pattern, pexpect.EOF]) == 0:
             pass
         else:
@@ -1188,7 +1188,7 @@ def check_pattern_visible_with_command_fortime(context, pattern, command, second
     seconds = int(seconds)
     orig_seconds = seconds
     while seconds > 0:
-        proc = pexpect.spawn(cmd, timeout = 180, logfile=context.log)
+        proc = pexpect.spawn(cmd, timeout = 180, logfile=context.log, encoding='utf-8')
         if proc.expect([pattern, pexpect.EOF]) != 0:
             pass
         else:
@@ -1203,7 +1203,7 @@ def check_pattern_not_visible_with_command_in_time(context, pattern, command, se
     seconds = int(seconds)
     orig_seconds = seconds
     while seconds > 0:
-        proc = pexpect.spawn(cmd, timeout = 180, logfile=context.log)
+        proc = pexpect.spawn(cmd, timeout = 180, logfile=context.log, encoding='utf-8')
         if proc.expect([pattern, pexpect.EOF]) != 0:
             return True
         seconds = seconds - 1
@@ -1214,7 +1214,7 @@ def check_pattern_not_visible_with_command_in_time(context, pattern, command, se
 @step(u'"{pattern}" is not visible with command "{command}"')
 def check_pattern_not_visible_with_command(context, pattern, command):
     cmd = '/bin/bash -c "%s"' %command
-    proc = pexpect.spawn(cmd, maxread=100000, logfile=context.log)
+    proc = pexpect.spawn(cmd, maxread=100000, logfile=context.log, encoding='utf-8')
     if proc.expect([pattern, pexpect.EOF]) == 0:
         sleep(1)
         proc = pexpect.spawn(cmd, maxread=100000, logfile=context.log)
@@ -1226,7 +1226,7 @@ def check_pattern_not_visible_with_command(context, pattern, command):
 @step(u'"{pattern}" is visible with tab after "{command}"')
 def check_pattern_visible_with_tab_after_command(context, pattern, command):
     os.system('echo "set page-completions off" > ~/.inputrc')
-    exp = pexpect.spawn('/bin/bash', logfile=context.log)
+    exp = pexpect.spawn('/bin/bash', logfile=context.log, encoding='utf-8')
     exp.send(command)
     exp.sendcontrol('i')
     exp.sendcontrol('i')
@@ -1239,7 +1239,7 @@ def check_pattern_visible_with_tab_after_command(context, pattern, command):
 @step(u'"{pattern}" is not visible with tab after "{command}"')
 def check_pattern_not_visible_with_tab_after_command(context, pattern, command):
     os.system('echo "set page-completions off" > ~/.inputrc')
-    exp = pexpect.spawn('/bin/bash', logfile=context.log)
+    exp = pexpect.spawn('/bin/bash', logfile=context.log, encoding='utf-8')
     exp.send(command)
     exp.sendcontrol('i')
     exp.sendcontrol('i')
@@ -1268,9 +1268,9 @@ def check_ifaces_in_state(context, exclude_ifaces, iface_state):
 @step(u'Ping "{domain}" "{number}" times')
 def ping_domain(context, domain, number=2):
     if number != 2:
-        ping = pexpect.spawn('ping -4 -c %s %s' %(number, domain), logfile=context.log)
+        ping = pexpect.spawn('ping -4 -c %s %s' %(number, domain), logfile=context.log, encoding='utf-8')
     else:
-        ping = pexpect.spawn('curl %s' %(domain), logfile=context.log)
+        ping = pexpect.spawn('curl %s' %(domain), logfile=context.log, encoding='utf-8')
     ping.expect([pexpect.EOF])
     ping.close()
     assert ping.exitstatus == 0
@@ -1278,7 +1278,7 @@ def ping_domain(context, domain, number=2):
 
 @step(u'Ping "{domain}" from "{device}" device')
 def ping_domain_from_device(context, domain, device):
-    ping = pexpect.spawn('ping -4 -c 2 -I %s %s' %(device, domain), logfile=context.log)
+    ping = pexpect.spawn('ping -4 -c 2 -I %s %s' %(device, domain), logfile=context.log, encoding='utf-8')
     ping.expect([pexpect.EOF])
     ping.close()
     assert ping.exitstatus == 0
@@ -1286,7 +1286,7 @@ def ping_domain_from_device(context, domain, device):
 
 @step(u'Ping6 "{domain}"')
 def ping6_domain(context, domain):
-    ping = pexpect.spawn('ping6 -c 2 %s' %domain, logfile=context.log)
+    ping = pexpect.spawn('ping6 -c 2 %s' %domain, logfile=context.log, encoding='utf-8')
     ping.expect([pexpect.EOF])
     ping.close()
     assert ping.exitstatus == 0
@@ -1598,7 +1598,7 @@ def start_NM(context):
 
 @step(u'Delete device "{device}"')
 def delete_device(context, device):
-    cli = pexpect.spawn('nmcli device delete %s' % device, logfile=context.log,  timeout=180)
+    cli = pexpect.spawn('nmcli device delete %s' % device, logfile=context.log,  timeout=180, encoding='utf-8')
 
     r = cli.expect(['Error', pexpect.TIMEOUT, pexpect.EOF])
     if r == 0:
@@ -1745,9 +1745,9 @@ def set_property_in_editor(context, name, value):
 @step(u'Set logging for "{domain}" to "{level}"')
 def set_logging(context, domain, level):
     if level == " ":
-        cli = pexpect.spawn('nmcli g l domains %s' % (domain), timeout = 60, logfile=context.log)
+        cli = pexpect.spawn('nmcli g l domains %s' % (domain), timeout = 60, logfile=context.log, encoding='utf-8')
     else:
-        cli = pexpect.spawn('nmcli g l level %s domains %s' % (level, domain), timeout = 60, logfile=context.log)
+        cli = pexpect.spawn('nmcli g l level %s domains %s' % (level, domain), timeout = 60, logfile=context.log, encoding='utf-8')
 
     r = cli.expect(['Error', 'Timeout', pexpect.TIMEOUT, pexpect.EOF])
     if r != 3:
@@ -1829,7 +1829,7 @@ def spawn_command(context, command):
 
 @step(u'Start generic connection "{connection}" for "{device}"')
 def start_generic_connection(context, connection, device):
-    cli = pexpect.spawn('nmcli connection up %s ifname %s' % (connection, device), timeout = 180, logfile=context.log)
+    cli = pexpect.spawn('nmcli connection up %s ifname %s' % (connection, device), timeout = 180, logfile=context.log, encoding='utf-8')
     r = cli.expect([pexpect.EOF, pexpect.TIMEOUT])
     if r != 0:
         raise Exception('nmcli connection up %s timed out (180s)' % connection)
@@ -1838,13 +1838,13 @@ def start_generic_connection(context, connection, device):
 
 @step(u'Start tailing file "{archivo}"')
 def start_tailing(context, archivo):
-    context.tail = pexpect.spawn('sudo tail -f %s' % archivo, timeout = 180, logfile=context.log)
+    context.tail = pexpect.spawn('sudo tail -f %s' % archivo, timeout = 180, logfile=context.log, encoding='utf-8')
     sleep(0.3)
 
 
 @step(u'Start following journal')
 def start_tailing_journal(context):
-    context.journal = pexpect.spawn('sudo journalctl --follow -o cat', timeout = 180, logfile=context.log)
+    context.journal = pexpect.spawn('sudo journalctl --follow -o cat', timeout = 180, logfile=context.log, encoding='utf-8')
     sleep(0.3)
 
 
@@ -1856,7 +1856,7 @@ def find_tailing_journal(context, content):
 
 @step(u'Team "{team}" is down')
 def team_is_down(context, team):
-    cmd = pexpect.spawn('teamdctl %s state dump' %team, logfile=context.log)
+    cmd = pexpect.spawn('teamdctl %s state dump' %team, logfile=context.log, encoding='utf-8')
     print (command_code(context, 'teamdctl %s state dump' %team))
     assert command_code(context, 'teamdctl %s state dump' %team) != 0, 'team "%s" exists' % (team)
 
@@ -1868,7 +1868,7 @@ def terminate_spawned_process(context, command):
 
 @step(u'Unable to ping "{domain}"')
 def cannot_ping_domain(context, domain):
-    ping = pexpect.spawn('curl %s' %domain, logfile=context.log)
+    ping = pexpect.spawn('curl %s' %domain, logfile=context.log, encoding='utf-8')
     ping.expect([pexpect.EOF])
     ping.close()
     assert ping.exitstatus != 0
@@ -1876,7 +1876,7 @@ def cannot_ping_domain(context, domain):
 
 @step(u'Unable to ping "{domain}" from "{device}" device')
 def cannot_ping_domain_from_device(context, domain, device):
-    ping = pexpect.spawn('ping -c 2 -I %s %s ' %(device, domain), logfile=context.log)
+    ping = pexpect.spawn('ping -c 2 -I %s %s ' %(device, domain), logfile=context.log, encoding='utf-8')
     ping.expect([pexpect.EOF])
     ping.close()
     assert ping.exitstatus != 0
@@ -1884,7 +1884,7 @@ def cannot_ping_domain_from_device(context, domain, device):
 
 @step(u'Unable to ping6 "{domain}"')
 def cannot_ping6_domain(context, domain):
-    ping = pexpect.spawn('ping6 -c 2 %s' %domain, logfile=context.log)
+    ping = pexpect.spawn('ping6 -c 2 %s' %domain, logfile=context.log, encoding='utf-8')
     ping.expect([pexpect.EOF])
     ping.close()
     assert ping.exitstatus != 0
@@ -1892,14 +1892,14 @@ def cannot_ping6_domain(context, domain):
 
 @step(u'"{user}" is able to see connection "{name}"')
 def is_readable(context, user, name):
-    cli = pexpect.spawn('sudo -u %s nmcli connection show configured %s' %(user, name))
+    cli = pexpect.spawn('sudo -u %s nmcli connection show configured %s' %(user, name), encoding='utf-8')
     if cli.expect(['connection.id:\s+gsm', 'Error', pexpect.TIMEOUT, pexpect.EOF]) != 0:
         raise Exception('Error while getting connection %s' % name)
 
 
 @step(u'"{user}" is not able to see connection "{name}"')
 def is_not_readable(context, user, name):
-    cli = pexpect.spawn('sudo -u %s nmcli connection show configured %s' %(user, name))
+    cli = pexpect.spawn('sudo -u %s nmcli connection show configured %s' %(user, name), encoding='utf-8')
     if cli.expect(['connection.id:\s+gsm', 'Error', pexpect.TIMEOUT, pexpect.EOF]) == 0:
         raise Exception('Connection %s is readable even if it should not be %s' % name)
 

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -691,7 +691,7 @@ def compare_devices(context):
 
         if a_type == 'dict':
             for a_key in a.keys():
-                if b.has_key(a_key):
+                if a_key in b:
                     if not deep_compare(a_desc + '.' + a_key, a[a_key],
                                 b_desc + '.' + a_key, b[a_key]):
                         ret = False
@@ -700,7 +700,7 @@ def compare_devices(context):
                     ret = False
 
             for b_key in b.keys():
-                if not a.has_key(b_key):
+                if b_key not in a:
                     print ('%s does not have %s' % (a_desc, b_key))
                     ret = False
         else:
@@ -1821,7 +1821,7 @@ def submit_team_command_in_editor(context, command):
 
 @step(u'Spawn "{command}" command')
 def spawn_command(context, command):
-    context.prompt = pexpect.spawn(command, logfile=context.log)
+    context.prompt = pexpect.spawn(command, logfile=context.log, encoding='utf-8')
     if not hasattr(context, 'spawned_processes'):
         context.spawned_processes = {}
     context.spawned_processes[command] = context.prompt

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -832,12 +832,12 @@ def execute_command(context, command):
 
 @step(u'Execute "{command}" for "{number}" times')
 def execute_multiple_times(context, command, number):
-    orig_nm_pid = check_output('pidof NetworkManager', shell=True)
+    orig_nm_pid = check_output('pidof NetworkManager', shell=True).decode('utf-8')
 
     i = 0
     while i < int(number):
         command_code(context, command)
-        curr_nm_pid = check_output('pidof NetworkManager', shell=True)
+        curr_nm_pid = check_output('pidof NetworkManager', shell=True).decode('utf-8')
         assert curr_nm_pid == orig_nm_pid, 'NM crashed as original pid was %s but now is %s' %(orig_nm_pid, curr_nm_pid)
         i += 1
 
@@ -912,7 +912,7 @@ def flag_cap_set(context, flag, n=None, device='wlan0', giveexception=True):
             org.freedesktop.DBus.Properties.Get \
             string:"org.freedesktop.NetworkManager.Device.Wireless" \
             string:"WirelessCapabilities" | grep variant | awk '{print $3}' ''' % path
-    ret = int(check_output(cmd, shell=True).strip())
+    ret = int(check_output(cmd, shell=True).decode('utf-8').strip())
 
     if n is None:
         if wcaps[flag] & ret == wcaps[flag]:
@@ -1019,7 +1019,7 @@ def check_metered_status(context, value):
                                                 org.freedesktop.DBus.Properties.Get \
                                                 string:"org.freedesktop.NetworkManager" \
                                                 string:"Metered" |grep variant| awk \'{print $3}\''
-    ret = check_output(cmd, shell=True).strip()
+    ret = check_output(cmd, shell=True).decode('utf-8').strip()
     assert ret == value, "Metered value is %s but should be %s" %(ret, value)
 
 @step(u'Network trafic "{state}" dropped')

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -1144,7 +1144,7 @@ def add_novice_connection(context):
 
 @step(u'"{pattern}" is visible with command "{command}"')
 def check_pattern_visible_with_command(context, pattern, command):
-    cmd = '/bin/bash -c "%s"' %command
+    cmd = "/bin/bash -c '%s'" %command
     proc = pexpect.spawn(cmd, maxread=100000, logfile=context.log, encoding='utf-8')
     if proc.expect([pattern, pexpect.EOF]) != 0:
         sleep(1)
@@ -1155,7 +1155,7 @@ def check_pattern_visible_with_command(context, pattern, command):
 
 @step(u'"{pattern}" is visible with command "{command}" in "{seconds}" seconds')
 def check_pattern_visible_with_command_in_time(context, pattern, command, seconds):
-    cmd = '/bin/bash -c "%s"' %command
+    cmd = "/bin/bash -c '%s'" %command
     seconds = int(seconds)
     orig_seconds = seconds
     while seconds > 0:
@@ -1169,7 +1169,7 @@ def check_pattern_visible_with_command_in_time(context, pattern, command, second
 
 @step(u'"{pattern}" is visible with command "{command}" for full "{seconds}" seconds')
 def check_pattern_visible_with_command_fortime(context, pattern, command, seconds):
-    cmd = '/bin/bash -c "%s"' %command
+    cmd = "/bin/bash -c '%s'" %command
     seconds = int(seconds)
     orig_seconds = seconds
     while seconds > 0:
@@ -1184,7 +1184,7 @@ def check_pattern_visible_with_command_fortime(context, pattern, command, second
 
 @step(u'"{pattern}" is not visible with command "{command}" for full "{seconds}" seconds')
 def check_pattern_visible_with_command_fortime(context, pattern, command, seconds):
-    cmd = '/bin/bash -c "%s"' %command
+    cmd = "/bin/bash -c '%s'" %command
     seconds = int(seconds)
     orig_seconds = seconds
     while seconds > 0:
@@ -1197,13 +1197,13 @@ def check_pattern_visible_with_command_fortime(context, pattern, command, second
         sleep(1)
 
 
-@step(u'"{pattern}" is not visible with command "{command}" in "{seconds}" seconds')
+@step('"{pattern}" is not visible with command "{command}" in "{seconds}" seconds')
 def check_pattern_not_visible_with_command_in_time(context, pattern, command, seconds):
-    cmd = '/bin/bash -c "%s"' %command
+    cmd = "/bin/bash -c '%s'" %command
     seconds = int(seconds)
     orig_seconds = seconds
     while seconds > 0:
-        proc = pexpect.spawn(cmd, timeout = 180, logfile=context.log, encoding='utf-8')
+        proc = pexpect.spawn(cmd.encode('utf-8'), timeout = 180, logfile=context.log, encoding='utf-8')
         if proc.expect([pattern, pexpect.EOF]) != 0:
             return True
         seconds = seconds - 1
@@ -1211,13 +1211,13 @@ def check_pattern_not_visible_with_command_in_time(context, pattern, command, se
     raise Exception('Did still see the pattern %s after %d seconds' % (pattern, orig_seconds))
 
 
-@step(u'"{pattern}" is not visible with command "{command}"')
+@step('"{pattern}" is not visible with command "{command}"')
 def check_pattern_not_visible_with_command(context, pattern, command):
-    cmd = '/bin/bash -c "%s"' %command
+    cmd = "/bin/bash -c '%s'" %command
     proc = pexpect.spawn(cmd, maxread=100000, logfile=context.log, encoding='utf-8')
     if proc.expect([pattern, pexpect.EOF]) == 0:
         sleep(1)
-        proc = pexpect.spawn(cmd, maxread=100000, logfile=context.log)
+        proc = pexpect.spawn(cmd, maxread=100000, logfile=context.log, encoding='utf-8')
         assert proc.expect([pattern, pexpect.EOF]) != 0, 'pattern %s is visible with %s' % (pattern, command)
     else:
         return True
@@ -1264,13 +1264,13 @@ def check_ifaces_in_state(context, exclude_ifaces, iface_state):
     check_pattern_not_visible_with_command(context, iface_state, cmd)
 
 
-@step(u'Ping "{domain}"')
-@step(u'Ping "{domain}" "{number}" times')
+@step('Ping "{domain}"')
+@step('Ping "{domain}" "{number}" times')
 def ping_domain(context, domain, number=2):
     if number != 2:
-        ping = pexpect.spawn('ping -4 -c %s %s' %(number, domain), logfile=context.log, encoding='utf-8')
+        ping = pexpect.spawn("ping -q -4 -c %s %s" %(number, domain), logfile=context.log, encoding='utf-8')
     else:
-        ping = pexpect.spawn('curl %s' %(domain), logfile=context.log, encoding='utf-8')
+        ping = pexpect.spawn("curl -s %s" %(domain), logfile=context.log, encoding='utf-8')
     ping.expect([pexpect.EOF])
     ping.close()
     assert ping.exitstatus == 0
@@ -1278,7 +1278,7 @@ def ping_domain(context, domain, number=2):
 
 @step(u'Ping "{domain}" from "{device}" device')
 def ping_domain_from_device(context, domain, device):
-    ping = pexpect.spawn('ping -4 -c 2 -I %s %s' %(device, domain), logfile=context.log, encoding='utf-8')
+    ping = pexpect.spawn("ping -4 -c 2 -I %s %s" %(device, domain), logfile=context.log, encoding='utf-8')
     ping.expect([pexpect.EOF])
     ping.close()
     assert ping.exitstatus == 0
@@ -1286,7 +1286,7 @@ def ping_domain_from_device(context, domain, device):
 
 @step(u'Ping6 "{domain}"')
 def ping6_domain(context, domain):
-    ping = pexpect.spawn('ping6 -c 2 %s' %domain, logfile=context.log, encoding='utf-8')
+    ping = pexpect.spawn("ping6 -c 2 %s" %domain, logfile=context.log, encoding='utf-8')
     ping.expect([pexpect.EOF])
     ping.close()
     assert ping.exitstatus == 0

--- a/nmcli/features/vpn.feature
+++ b/nmcli/features/vpn.feature
@@ -80,4 +80,4 @@
     @pptp
     @vpn_list_args
     Scenario: nmcli - vpn - list args
-    Then "libreswan|vpnc|openvpn|org.freedesktop.NetworkManager.libreswan" is visible with command "nmcli --complete-args connection add type vpn vpn-type ''"
+    Then "libreswan|vpnc|openvpn" is visible with command "nmcli --complete-args connection add type vpn vpn-type """

--- a/nmtui/features/environment.py
+++ b/nmtui/features/environment.py
@@ -16,14 +16,14 @@ def get_cursored_screen(screen):
 def print_screen(screen):
     cursored_screen = get_cursored_screen(screen)
     for i in range(len(cursored_screen)):
-        print (cursored_screen[i].encode('utf-8'))
+        print (cursored_screen[i])
 
 def log_screen(stepname, screen, path):
     cursored_screen = get_cursored_screen(screen)
     f = open(path, 'a+')
     f.write(stepname + '\n')
     for i in range(len(cursored_screen)):
-        f.write(cursored_screen[i].encode('utf-8') + '\n')
+        f.write(cursored_screen[i] + '\n')
     f.flush()
     f.close()
 
@@ -49,13 +49,13 @@ def before_all(context):
         os.system("sudo pkill nmtui")
 
         # Store scenario start cursor for session logs
-        context.log_cursor = check_output("journalctl --lines=0 --show-cursor |awk '/^-- cursor:/ {print \"\\\"--after-cursor=\"$NF\"\\\"\"; exit}'", shell=True).strip()
+        context.log_cursor = check_output("journalctl --lines=0 --show-cursor |awk '/^-- cursor:/ {print \"\\\"--after-cursor=\"$NF\"\\\"\"; exit}'", shell=True).decode('utf-8').strip()
     except Exception:
         print("Error in before_all:")
         traceback.print_exc(file=sys.stdout)
 
 def reset_hwaddr(ifname):
-    hwaddr = check_output("ethtool -P %s" % ifname, shell=True).split()[2]
+    hwaddr = check_output("ethtool -P %s" % ifname, shell=True).decode('utf-8').split()[2]
     call("ip link set %s address %s" % (ifname, hwaddr), shell=True)
 
 def before_scenario(context, scenario):
@@ -119,7 +119,7 @@ def after_step(context, step):
     try:
         sleep(0.5)
         if os.path.isfile('/tmp/nmtui.out'):
-            context.stream.feed(open('/tmp/nmtui.out', 'r').read())
+            context.stream.feed(open('/tmp/nmtui.out', 'r').read().encode('utf-8'))
         print_screen(context.screen)
         log_screen(step.name, context.screen, '/tmp/tui-screen.log')
 

--- a/nmtui/features/environment.py
+++ b/nmtui/features/environment.py
@@ -1,7 +1,12 @@
 # -*- coding: UTF-8 -*-
 
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import sys
+
+reload(sys)
+sys.setdefaultencoding('utf8')
+
 import traceback
 from time import sleep, localtime, strftime
 from subprocess import call, check_output
@@ -78,7 +83,6 @@ def before_scenario(context, scenario):
                 f.write('INFO: VETH SETUP: this test has been disabled in VETH setup')
                 f.flush()
                 f.close()
-                import sys
                 sys.exit(0)
         if 'veth' in scenario.tags:
             if os.path.isfile('/tmp/nm_veth_configured'):
@@ -88,7 +92,6 @@ def before_scenario(context, scenario):
                 f.write('INFO: VETH mod: this test has been disabled in VETH setup')
                 f.flush()
                 f.close()
-                import sys
                 sys.exit(0)
         if 'eth0' in scenario.tags:
             print ("---------------------------")
@@ -133,7 +136,6 @@ def after_step(context, step):
             f.write('INFO: Skiped the test as device does not support AP/ADHOC mode')
             f.flush()
             f.close()
-            import sys
             sys.exit(0)
 
         if step.status == 'failed':

--- a/nmtui/features/environment.py
+++ b/nmtui/features/environment.py
@@ -3,9 +3,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import sys
-
-reload(sys)
-sys.setdefaultencoding('utf8')
+if sys.version_info < (3, 0):
+    reload(sys)
+    sys.setdefaultencoding('utf8')
 
 import traceback
 from time import sleep, localtime, strftime

--- a/nmtui/features/ipv4.feature
+++ b/nmtui/features/ipv4.feature
@@ -183,7 +183,7 @@ Feature: IPv4 TUI tests
     * Set "Gateway" field to "192.168.253.96"
     * Confirm the connection settings
     Then "GATEWAY=192.168.253.96" is visible with command "cat /etc/sysconfig/network-scripts/ifcfg-ethernet"
-    Then "inet 192.168[^ ]* brd 192.168[^ ]* scope global( noprefixroute)? dynamic eth1" is visible with command "ip a s eth1" in "10" seconds
+    Then "inet 192.168[^ ]* brd 192.168[^ ]* scope global( noprefixroute)? dynamic( noprefixroute)? eth1" is visible with command "ip a s eth1" in "10" seconds
     Then "192.168.253.101/24" is visible with command "ip a s eth1"
     Then "192.168.253.102/24" is visible with command "ip a s eth1"
     Then "192.168.253.103/24" is visible with command "ip a s eth1"

--- a/nmtui/features/steps/steps.py
+++ b/nmtui/features/steps/steps.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python
-
+# -*- coding: UTF-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import pyte
 import pexpect
@@ -47,7 +47,7 @@ keys['F12'] = "\x1b\x5b\x32\x34\x7e"
 
 def print_screen_wo_cursor(screen):
     for i in range(len(screen.display)):
-        print(screen.display[i].encode('utf-8'))
+        print(screen.display[i])
 
 def get_cursored_screen(screen):
     myscreen_display = screen.display
@@ -63,15 +63,15 @@ def get_screen_string(screen):
 def print_screen(screen):
     cursored_screen = get_cursored_screen(screen)
     for i in range(len(cursored_screen)):
-        print(cursored_screen[i].encode('utf-8'))
+        print(cursored_screen[i])
 
 def feed_print_screen(context):
     if os.path.isfile('/tmp/nmtui.out'):
-        context.stream.feed(open('/tmp/nmtui.out', 'r').read())
+        context.stream.feed(open('/tmp/nmtui.out', 'r').read().encode('utf-8'))
     print_screen(context.screen)
 
 def feed_stream(stream):
-    stream.feed(open(OUTPUT, 'r').read())
+    stream.feed(open(OUTPUT, 'r').read().encode('utf-8'))
 
 def init_screen():
     stream = pyte.ByteStream()
@@ -81,7 +81,7 @@ def init_screen():
 
 def go_until_pattern_matches_line(context, key, pattern, limit=50):
     sleep(0.2)
-    context.stream.feed(open(OUTPUT, 'r').read())
+    context.stream.feed(open(OUTPUT, 'r').read().encode('utf-8'))
     for i in range(0,limit):
         match = re.match(pattern, context.screen.display[context.screen.cursor.y], re.UNICODE)
         if match is not None:
@@ -89,25 +89,25 @@ def go_until_pattern_matches_line(context, key, pattern, limit=50):
         else:
             context.tui.send(key)
             sleep(0.3)
-            context.stream.feed(open(OUTPUT, 'r').read())
+            context.stream.feed(open(OUTPUT, 'r').read().encode('utf-8'))
     return None
 
 
 def go_until_pattern_matches_aftercursor_text(context, key, pattern, limit=50, include_precursor_char=True):
     pre_c = 0
     sleep(0.2)
-    context.stream.feed(open(OUTPUT, 'r').read())
+    context.stream.feed(open(OUTPUT, 'r').read().encode('utf-8'))
     if include_precursor_char is True:
         pre_c = -1
     for i in range(0,limit):
         match = re.match(pattern, context.screen.display[context.screen.cursor.y][context.screen.cursor.x+pre_c:], re.UNICODE)
-        print(context.screen.display[context.screen.cursor.y].encode('utf-8'))
+        print(context.screen.display[context.screen.cursor.y])
         if match is not None:
             return match
         else:
             context.tui.send(key)
             sleep(0.3)
-            context.stream.feed(open(OUTPUT, 'r').read())
+            context.stream.feed(open(OUTPUT, 'r').read().encode('utf-8'))
     return None
 
 def dump_command_output(command):
@@ -128,7 +128,7 @@ def prepare_environment(context):
 
 @step(u'Start nmtui')
 def start_nmtui(context):
-    context.tui = pexpect.spawn('sh -c "TERM=%s nmtui > %s"' % (TERM_TYPE, OUTPUT))
+    context.tui = pexpect.spawn('sh -c "TERM=%s nmtui > %s"' % (TERM_TYPE, OUTPUT), encoding='utf-8')
     sleep(3)
 
 
@@ -214,7 +214,7 @@ def back_to_con_list(context):
 
 @step(u'Come back to main screen')
 def back_to_main(context):
-    current_nm_version = "".join(check_output("""NetworkManager -V |awk 'BEGIN { FS = "." }; {printf "%03d%03d%03d", $1, $2, $3}'""", shell=True).split('-')[0])
+    current_nm_version = "".join(check_output("""NetworkManager -V |awk 'BEGIN { FS = "." }; {printf "%03d%03d%03d", $1, $2, $3}'""", shell=True).decode('utf-8').split('-')[0])
     context.tui.send(keys['ESCAPE'])
     if current_nm_version < "001003000":
         context.execute_steps(u'* Start nmtui')
@@ -231,7 +231,7 @@ def choose_connection_action(context, action):
 
 @step(u'Bring up connection "{connection}"')
 def bring_up_connection(context, connection):
-    cli = pexpect.spawn('nmcli connection up %s' % connection, timeout = 180)
+    cli = pexpect.spawn('nmcli connection up %s' % connection, encoding='utf-8', timeout = 180)
     r = cli.expect(['Error', pexpect.TIMEOUT, pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while upping connection %s' % connection)
@@ -249,7 +249,7 @@ def bring_up_connection_ignore_everything(context, connection):
 def confirm_route_screen(context):
     context.tui.send(keys['DOWNARROW']*64)
     sleep(0.2)
-    context.stream.feed(open(OUTPUT, 'r').read())
+    context.stream.feed(open(OUTPUT, 'r').read().encode('utf-8'))
     match = re.match(r'^<OK>.*', context.screen.display[context.screen.cursor.y][context.screen.cursor.x-1:], re.UNICODE)
     assert match is not None, "Could not get to the <OK> route dialog button!"
     context.tui.send(keys['ENTER'])
@@ -259,7 +259,7 @@ def confirm_route_screen(context):
 def confirm_slave_screen(context):
     context.tui.send(keys['DOWNARROW']*64)
     sleep(0.2)
-    context.stream.feed(open(OUTPUT, 'r').read())
+    context.stream.feed(open(OUTPUT, 'r').read().encode('utf-8'))
     match = re.match(r'^<OK>.*', context.screen.display[context.screen.cursor.y][context.screen.cursor.x-1:], re.UNICODE)
     assert match is not None, "Could not get to the <OK> button! (In form? Segfault?)"
     context.tui.send(keys['ENTER'])
@@ -269,7 +269,7 @@ def confirm_slave_screen(context):
 def confirm_connection_screen(context):
     context.tui.send(keys['DOWNARROW']*64)
     sleep(0.2)
-    context.stream.feed(open(OUTPUT, 'r').read())
+    context.stream.feed(open(OUTPUT, 'r').read().encode('utf-8'))
     match = re.match(r'^<OK>.*', context.screen.display[context.screen.cursor.y][context.screen.cursor.x-1:], re.UNICODE)
     assert match is not None, "Could not get to the <OK> button! (In form? Segfault?)"
     context.tui.send(keys['ENTER'])
@@ -279,7 +279,7 @@ def confirm_connection_screen(context):
 def cannot_confirm_connection_screen(context):
     context.tui.send(keys['DOWNARROW']*64)
     sleep(0.2)
-    context.stream.feed(open(OUTPUT, 'r').read())
+    context.stream.feed(open(OUTPUT, 'r').read().encode('utf-8'))
     match = re.match(r'^<Cancel>.*', context.screen.display[context.screen.cursor.y][context.screen.cursor.x-1:], re.UNICODE)
     assert match is not None, "<OK> button is likely not greyed got: %s at the last line" % match.group(1)
 
@@ -419,7 +419,7 @@ def execute_command(context, command):
 
 @step(u'Note the output of "{command}"')
 def note_the_output_of(context, command):
-    context.noted_value = subprocess.check_output(command, shell=True).strip() # kill the \n
+    context.noted_value = subprocess.check_output(command, shell=True).decode('utf-8').strip() # kill the \n
 
 
 @step(u'Restore hostname from the noted value')
@@ -431,10 +431,10 @@ def restore_hostname(context):
 @step(u'"{pattern}" is visible with command "{command}"')
 def check_pattern_visible_with_command(context, pattern, command):
     cmd = '/bin/bash -c "%s"' %command
-    proc = pexpect.spawn(cmd, maxread=100000)
+    proc = pexpect.spawn(cmd, encoding='utf-8', maxread=100000)
     if proc.expect([pattern, pexpect.EOF]) != 0:
         sleep(1)
-        proc = pexpect.spawn(cmd, maxread=100000)
+        proc = pexpect.spawn(cmd, encoding='utf-8', maxread=100000)
         res = proc.expect([pattern, pexpect.EOF])
         if res != 0:
             dump_command_output(command)
@@ -661,7 +661,7 @@ def flag_cap_set(context, flag, n=None, device='wlan0', giveexception=True):
             org.freedesktop.DBus.Properties.Get \
             string:"org.freedesktop.NetworkManager.Device.Wireless" \
             string:"WirelessCapabilities" | grep variant | awk '{print $3}' ''' % path
-    ret = int(subprocess.check_output(cmd, shell=True).strip())
+    ret = int(subprocess.check_output(cmd, shell=True).decode('utf-8').strip())
 
     if n is None:
         if wcaps[flag] & ret == wcaps[flag]:

--- a/nmtui/runtest.sh
+++ b/nmtui/runtest.sh
@@ -5,7 +5,7 @@ logger -t $0 "Running test $1"
 export PATH=$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin
 DIR=$(pwd)
 
-. $DIR/prepare/devsetup.sh
+. $DIR/prepare/envsetup.sh
 setup_configure_environment "$1"
 
 # install the pyte VT102 emulator

--- a/prepare/envsetup.sh
+++ b/prepare/envsetup.sh
@@ -89,6 +89,11 @@ local_setup_configure_nm_eth () {
         yum -y install https://kojipkgs.fedoraproject.org//packages/tcpreplay/4.2.5/4.fc28/$(uname -p)/tcpreplay-4.2.5-4.fc28.$(uname -p).rpm
         yum install -y http://download.eng.bos.redhat.com/brewroot/packages/python-behave/1.2.5/23.el8+7/noarch/python3-behave-1.2.5-23.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse/1.6.6/8.el8+7/noarch/python3-parse-1.6.6-8.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse_type/0.3.4/15.el8+7/noarch/python3-parse_type-0.3.4-15.el8+7.noarch.rpm
         ln -s /usr/bin/behave-3 /usr/bin/behave
+
+        # Make python3 default if it's not
+        rm -rf /usr/bin/python
+        ln -s /usr/bin/python3 /usr/bin/python
+
         #yum -y install https://kojipkgs.fedoraproject.org//packages/python-six/1.9.0/2.fc23/noarch/python-six-1.9.0-2.fc23.noarch.rpm https://kojipkgs.fedoraproject.org//packages/python-behave/1.2.5/18.el7/noarch/python2-behave-1.2.5-18.el7.noarch.rpm https://kojipkgs.fedoraproject.org//packages/python-enum34/1.1.6/4.fc28/noarch/python2-enum34-1.1.6-4.fc28.noarch.rpm
         yum -y remove NetworkManager-config-connectivity-fedora --skip-broken
         yum -y install http://download.eng.bos.redhat.com/brewroot/packages/openvswitch/2.9.0/3.el8+7/$(uname -p)/openvswitch-2.9.0-3.el8+7.$(uname -p).rpm

--- a/prepare/envsetup.sh
+++ b/prepare/envsetup.sh
@@ -81,13 +81,14 @@ local_setup_configure_nm_eth () {
     if grep -q Ootpa /etc/redhat-release; then
         yum -y install python3-pip
         pip install --upgrade pip
-        pip install pexpect
+        pip install python3-pexpect
         pip install pyroute2
         yum -y install git python-netaddr iw net-tools wireshark teamd bash-completion radvd psmisc bridge-utils firewalld dhcp ethtool dbus-python pygobject3 pygobject2 dnsmasq tcpdump --skip-broken
         yum -y install http://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/p/python2-dbus-1.2.4-13.fc28.x86_64.rpm
         yum -y remove python2-six python-six
         yum -y install https://kojipkgs.fedoraproject.org//packages/tcpreplay/4.2.5/4.fc28/$(uname -p)/tcpreplay-4.2.5-4.fc28.$(uname -p).rpm
-        yum install http://download.eng.bos.redhat.com/brewroot/packages/python-behave/1.2.5/23.el8+7/noarch/python3-behave-1.2.5-23.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse/1.6.6/8.el8+7/noarch/python3-parse-1.6.6-8.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse_type/0.3.4/15.el8+7/noarch/python3-parse_type-0.3.4-15.el8+7.noarch.rpm
+        yum install -y http://download.eng.bos.redhat.com/brewroot/packages/python-behave/1.2.5/23.el8+7/noarch/python3-behave-1.2.5-23.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse/1.6.6/8.el8+7/noarch/python3-parse-1.6.6-8.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse_type/0.3.4/15.el8+7/noarch/python3-parse_type-0.3.4-15.el8+7.noarch.rpm
+        ln -s /usr/bin/behave-3 /usr/bin/behave
         #yum -y install https://kojipkgs.fedoraproject.org//packages/python-six/1.9.0/2.fc23/noarch/python-six-1.9.0-2.fc23.noarch.rpm https://kojipkgs.fedoraproject.org//packages/python-behave/1.2.5/18.el7/noarch/python2-behave-1.2.5-18.el7.noarch.rpm https://kojipkgs.fedoraproject.org//packages/python-enum34/1.1.6/4.fc28/noarch/python2-enum34-1.1.6-4.fc28.noarch.rpm
         yum -y remove NetworkManager-config-connectivity-fedora --skip-broken
         yum -y install http://download.eng.bos.redhat.com/brewroot/packages/openvswitch/2.9.0/3.el8+7/$(uname -p)/openvswitch-2.9.0-3.el8+7.$(uname -p).rpm

--- a/prepare/envsetup.sh
+++ b/prepare/envsetup.sh
@@ -84,7 +84,7 @@ local_setup_configure_nm_eth () {
         pip install pyroute2
         yum -y install python3-pexpect
         yum -y install git python-netaddr iw net-tools wireshark teamd bash-completion radvd psmisc bridge-utils firewalld dhcp ethtool dbus-python pygobject3 pygobject2 dnsmasq tcpdump --skip-broken
-        yum -y install http://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/p/python2-dbus-1.2.4-13.fc28.x86_64.rpm
+        yum -y install http://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/$(uname -p)/os/Packages/p/python2-dbus-1.2.4-13.fc28.$(uname -p).rpm
         yum -y remove python2-six python-six
         yum -y install https://kojipkgs.fedoraproject.org//packages/tcpreplay/4.2.5/4.fc28/$(uname -p)/tcpreplay-4.2.5-4.fc28.$(uname -p).rpm
         yum install -y http://download.eng.bos.redhat.com/brewroot/packages/python-behave/1.2.5/23.el8+7/noarch/python3-behave-1.2.5-23.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse/1.6.6/8.el8+7/noarch/python3-parse-1.6.6-8.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse_type/0.3.4/15.el8+7/noarch/python3-parse_type-0.3.4-15.el8+7.noarch.rpm
@@ -93,6 +93,9 @@ local_setup_configure_nm_eth () {
         # Make python3 default if it's not
         rm -rf /usr/bin/python
         ln -s /usr/bin/python3 /usr/bin/python
+
+        # Install bridge-utils until these are obsoleted for ip
+        yum install -y https://kojipkgs.fedoraproject.org//packages/bridge-utils/1.6/1.fc29/$(uname -p)/bridge-utils-1.6-1.fc29.$(uname -p).rpm
 
         #yum -y install https://kojipkgs.fedoraproject.org//packages/python-six/1.9.0/2.fc23/noarch/python-six-1.9.0-2.fc23.noarch.rpm https://kojipkgs.fedoraproject.org//packages/python-behave/1.2.5/18.el7/noarch/python2-behave-1.2.5-18.el7.noarch.rpm https://kojipkgs.fedoraproject.org//packages/python-enum34/1.1.6/4.fc28/noarch/python2-enum34-1.1.6-4.fc28.noarch.rpm
         yum -y remove NetworkManager-config-connectivity-fedora --skip-broken

--- a/prepare/envsetup.sh
+++ b/prepare/envsetup.sh
@@ -101,6 +101,9 @@ local_setup_configure_nm_eth () {
         # Install bridge-utils until these are obsoleted for ip
         yum install -y https://kojipkgs.fedoraproject.org//packages/bridge-utils/1.6/1.fc29/$(uname -p)/bridge-utils-1.6-1.fc29.$(uname -p).rpm
 
+        # Install openvpn dependencies
+        yum -y install https://kojipkgs.fedoraproject.org//packages/NetworkManager-openvpn/1.8.4/1.fc28/x86_64/NetworkManager-openvpn-1.8.4-1.fc28.x86_64.rpm https://kojipkgs.fedoraproject.org//packages/openvpn/2.4.6/1.fc28/x86_64/openvpn-2.4.6-1.fc28.x86_64.rpm
+
         # Install various NM dependencies
         yum -y remove NetworkManager-config-connectivity-fedora --skip-broken
         yum -y install http://download.eng.bos.redhat.com/brewroot/packages/openvswitch/2.9.0/3.el8+7/$(uname -p)/openvswitch-2.9.0-3.el8+7.$(uname -p).rpm

--- a/prepare/envsetup.sh
+++ b/prepare/envsetup.sh
@@ -79,25 +79,29 @@ local_setup_configure_nm_eth () {
 
     #installing pip, behave, and pexpect and other deps
     if grep -q Ootpa /etc/redhat-release; then
-        yum -y install python3-pip
-        pip install --upgrade pip
-        pip install pyroute2
-        yum -y install python3-pexpect
-        yum -y install git python-netaddr iw net-tools wireshark teamd bash-completion radvd psmisc bridge-utils firewalld dhcp ethtool dbus-python pygobject3 pygobject2 dnsmasq tcpdump --skip-broken
-        yum -y install http://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/$(uname -p)/os/Packages/p/python2-dbus-1.2.4-13.fc28.$(uname -p).rpm
-        yum -y remove python2-six python-six
-        yum -y install https://kojipkgs.fedoraproject.org//packages/tcpreplay/4.2.5/4.fc28/$(uname -p)/tcpreplay-4.2.5-4.fc28.$(uname -p).rpm
-        yum install -y http://download.eng.bos.redhat.com/brewroot/packages/python-behave/1.2.5/23.el8+7/noarch/python3-behave-1.2.5-23.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse/1.6.6/8.el8+7/noarch/python3-parse-1.6.6-8.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse_type/0.3.4/15.el8+7/noarch/python3-parse_type-0.3.4-15.el8+7.noarch.rpm
-        ln -s /usr/bin/behave-3 /usr/bin/behave
-
         # Make python3 default if it's not
         rm -rf /usr/bin/python
         ln -s /usr/bin/python3 /usr/bin/python
 
+        # Pip down some deps
+        yum -y install python3-pip
+        python -m pip install --upgrade pip
+        python -m pip install pyroute2
+        python -m pip install pexpect
+        python -m pip install netaddr
+
+        # Yum more deps
+        yum -y install git python-netaddr iw net-tools wireshark teamd bash-completion radvd psmisc bridge-utils firewalld dhcp ethtool dbus-python pygobject3 pygobject2 dnsmasq tcpdump --skip-broken
+
+        # Install behave with better reporting
+        yum -y install https://kojipkgs.fedoraproject.org//packages/tcpreplay/4.2.5/4.fc28/$(uname -p)/tcpreplay-4.2.5-4.fc28.$(uname -p).rpm
+        yum install -y http://download.eng.bos.redhat.com/brewroot/packages/python-behave/1.2.5/23.el8+7/noarch/python3-behave-1.2.5-23.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse/1.6.6/8.el8+7/noarch/python3-parse-1.6.6-8.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse_type/0.3.4/15.el8+7/noarch/python3-parse_type-0.3.4-15.el8+7.noarch.rpm
+        ln -s /usr/bin/behave-3 /usr/bin/behave
+
         # Install bridge-utils until these are obsoleted for ip
         yum install -y https://kojipkgs.fedoraproject.org//packages/bridge-utils/1.6/1.fc29/$(uname -p)/bridge-utils-1.6-1.fc29.$(uname -p).rpm
 
-        #yum -y install https://kojipkgs.fedoraproject.org//packages/python-six/1.9.0/2.fc23/noarch/python-six-1.9.0-2.fc23.noarch.rpm https://kojipkgs.fedoraproject.org//packages/python-behave/1.2.5/18.el7/noarch/python2-behave-1.2.5-18.el7.noarch.rpm https://kojipkgs.fedoraproject.org//packages/python-enum34/1.1.6/4.fc28/noarch/python2-enum34-1.1.6-4.fc28.noarch.rpm
+        # Install various NM dependencies
         yum -y remove NetworkManager-config-connectivity-fedora --skip-broken
         yum -y install http://download.eng.bos.redhat.com/brewroot/packages/openvswitch/2.9.0/3.el8+7/$(uname -p)/openvswitch-2.9.0-3.el8+7.$(uname -p).rpm
         yum -y install http://download.eng.bos.redhat.com/brewroot/packages/$(rpm -q --queryformat '%{NAME}/%{VERSION}/%{RELEASE}' NetworkManager)/$(uname -p)/NetworkManager-ovs-$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' NetworkManager).$(uname -p).rpm  http://download.eng.bos.redhat.com/brewroot/packages/openvswitch/2.9.0/3.el8+7/$(uname -p)/openvswitch-2.9.0-3.el8+7.$(uname -p).rpm

--- a/prepare/envsetup.sh
+++ b/prepare/envsetup.sh
@@ -90,6 +90,8 @@ local_setup_configure_nm_eth () {
         python -m pip install pexpect
         python -m pip install netaddr
         python -m pip install pyte
+        python -m pip install IPy
+        
         # Yum more deps
         yum -y install git python-netaddr iw net-tools wireshark teamd bash-completion radvd psmisc bridge-utils firewalld dhcp ethtool dbus-python pygobject3 pygobject2 dnsmasq tcpdump --skip-broken
 

--- a/prepare/envsetup.sh
+++ b/prepare/envsetup.sh
@@ -89,7 +89,7 @@ local_setup_configure_nm_eth () {
         python -m pip install pyroute2
         python -m pip install pexpect
         python -m pip install netaddr
-
+        python -m pip install pyte
         # Yum more deps
         yum -y install git python-netaddr iw net-tools wireshark teamd bash-completion radvd psmisc bridge-utils firewalld dhcp ethtool dbus-python pygobject3 pygobject2 dnsmasq tcpdump --skip-broken
 

--- a/prepare/envsetup.sh
+++ b/prepare/envsetup.sh
@@ -79,7 +79,7 @@ local_setup_configure_nm_eth () {
 
     #installing pip, behave, and pexpect and other deps
     if grep -q Ootpa /etc/redhat-release; then
-        yum -y install python2-pip
+        yum -y install python3-pip
         pip install --upgrade pip
         pip install pexpect
         pip install pyroute2
@@ -87,7 +87,8 @@ local_setup_configure_nm_eth () {
         yum -y install http://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/p/python2-dbus-1.2.4-13.fc28.x86_64.rpm
         yum -y remove python2-six python-six
         yum -y install https://kojipkgs.fedoraproject.org//packages/tcpreplay/4.2.5/4.fc28/$(uname -p)/tcpreplay-4.2.5-4.fc28.$(uname -p).rpm
-        yum -y install https://kojipkgs.fedoraproject.org//packages/python-six/1.9.0/2.fc23/noarch/python-six-1.9.0-2.fc23.noarch.rpm https://kojipkgs.fedoraproject.org//packages/python-behave/1.2.5/18.el7/noarch/python2-behave-1.2.5-18.el7.noarch.rpm https://kojipkgs.fedoraproject.org//packages/python-enum34/1.1.6/4.fc28/noarch/python2-enum34-1.1.6-4.fc28.noarch.rpm
+        yum install http://download.eng.bos.redhat.com/brewroot/packages/python-behave/1.2.5/23.el8+7/noarch/python3-behave-1.2.5-23.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse/1.6.6/8.el8+7/noarch/python3-parse-1.6.6-8.el8+7.noarch.rpm http://download.eng.bos.redhat.com/brewroot/packages/python-parse_type/0.3.4/15.el8+7/noarch/python3-parse_type-0.3.4-15.el8+7.noarch.rpm
+        #yum -y install https://kojipkgs.fedoraproject.org//packages/python-six/1.9.0/2.fc23/noarch/python-six-1.9.0-2.fc23.noarch.rpm https://kojipkgs.fedoraproject.org//packages/python-behave/1.2.5/18.el7/noarch/python2-behave-1.2.5-18.el7.noarch.rpm https://kojipkgs.fedoraproject.org//packages/python-enum34/1.1.6/4.fc28/noarch/python2-enum34-1.1.6-4.fc28.noarch.rpm
         yum -y remove NetworkManager-config-connectivity-fedora --skip-broken
         yum -y install http://download.eng.bos.redhat.com/brewroot/packages/openvswitch/2.9.0/3.el8+7/$(uname -p)/openvswitch-2.9.0-3.el8+7.$(uname -p).rpm
         yum -y install http://download.eng.bos.redhat.com/brewroot/packages/$(rpm -q --queryformat '%{NAME}/%{VERSION}/%{RELEASE}' NetworkManager)/$(uname -p)/NetworkManager-ovs-$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' NetworkManager).$(uname -p).rpm  http://download.eng.bos.redhat.com/brewroot/packages/openvswitch/2.9.0/3.el8+7/$(uname -p)/openvswitch-2.9.0-3.el8+7.$(uname -p).rpm

--- a/prepare/envsetup.sh
+++ b/prepare/envsetup.sh
@@ -81,8 +81,8 @@ local_setup_configure_nm_eth () {
     if grep -q Ootpa /etc/redhat-release; then
         yum -y install python3-pip
         pip install --upgrade pip
-        pip install python3-pexpect
         pip install pyroute2
+        yum -y install python3-pexpect
         yum -y install git python-netaddr iw net-tools wireshark teamd bash-completion radvd psmisc bridge-utils firewalld dhcp ethtool dbus-python pygobject3 pygobject2 dnsmasq tcpdump --skip-broken
         yum -y install http://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/p/python2-dbus-1.2.4-13.fc28.x86_64.rpm
         yum -y remove python2-six python-six

--- a/tmp/dbus-set-gw.py
+++ b/tmp/dbus-set-gw.py
@@ -9,7 +9,7 @@ def ip_to_str(ip):
 
 def print_ipv4(setting):
     for address in setting["ipv4"]["addresses"]:
-        print ip_to_str(address[0]), address[1], ip_to_str(address[2])
+        print (ip_to_str(address[0]), address[1], ip_to_str(address[2]))
 
 def ip_to_int(ip_string):
     return struct.unpack("=I", socket.inet_aton(ip_string))[0]
@@ -29,7 +29,7 @@ s = dbus.Dictionary({
     },
     'ipv4': {
         'addresses': dbus.Array([
-            [ip_to_int('192.168.1.1'), dbus.UInt32(24L), 0]
+            [ip_to_int('192.168.1.1'), dbus.UInt32(24), 0]
         ], signature='au'),
         'method': 'manual'
     },
@@ -42,13 +42,13 @@ o = bus.get_object('org.freedesktop.NetworkManager', object_path)
 
 setting = o.GetSettings(dbus_interface='org.freedesktop.NetworkManager.Settings.Connection')
 
-print "Original state: 1 address without gateway"
+print ("Original state: 1 address without gateway")
 print_ipv4(setting)
-print
+print()
 
-setting["ipv4"]["addresses"].append([ip_to_int('192.168.1.1'), dbus.UInt32(24L), ip_to_int('192.168.1.100')])
+setting["ipv4"]["addresses"].append([ip_to_int('192.168.1.1'), dbus.UInt32(24), ip_to_int('192.168.1.100')])
 
-print "Updating: add address with gateway"
+print ("Updating: add address with gateway")
 print_ipv4(setting)
-print
+print ()
 o.Update(setting, dbus_interface='org.freedesktop.NetworkManager.Settings.Connection')

--- a/tmp/network_test.py
+++ b/tmp/network_test.py
@@ -25,9 +25,9 @@ def _activate_callback(client, result, data):
     # data is a threading.Event() used for signalling done
     try:
         client.activate_connection_finish(result)
-        print "Successfully activated"
+        print ("Successfully activated")
     except Exception as e:
-        print "Failed activating connection: {}".format(e)
+        print ("Failed activating connection: {}".format(e))
     data.set()
 
 
@@ -40,31 +40,31 @@ def activate_connection():
         raise Exception(
             "Timeout during activation of {}"
             .format(connection_name))
-    print "Done activating"
+    print ("Done activating")
 
 
 before_cons = nmclient.get_active_connections()
 
-print "Active connections before: %d" % (len(before_cons))
-print
-print "before_cons:  %s" % before_cons
-print
+print ("Active connections before: %d" % (len(before_cons)))
+print ()
+print ("before_cons:  %s" % before_cons)
+print ()
 
 counter = 1
 
 for nmobj in before_cons:
-	print
-	print " Connection %d: %s" % (counter, nmobj.get_uuid())
-	print " Connection state: %s" % nmobj.get_state()
-        print " get_devices():  %s" % nmobj.get_devices()
+    print ()
+    print (" Connection %d: %s" % (counter, nmobj.get_uuid()))
+    print (" Connection state: %s" % nmobj.get_state())
+    print (" get_devices():  %s" % nmobj.get_devices())
 
-	for device in nmobj.get_devices():
-		print "  Device: %s" % device.get_iface()
+    for device in nmobj.get_devices():
+        print ("  Device: %s" % device.get_iface())
 
-	counter += 1
+    counter += 1
 
-print
-print "Activating connection %s..." % connection_name
+print ()
+print ("Activating connection %s..." % connection_name)
 
 activate_connection()
 
@@ -74,25 +74,25 @@ loop = 2
 
 while loop != 0:
 
-	print
-	print "Active connections after: %d" % (len(after_cons))
-	print
-	print "after_cons:  %s" % after_cons
+    print ()
+    print ("Active connections after: %d" % (len(after_cons)))
+    print ()
+    print ("after_cons:  %s" % after_cons)
 
-	counter = 1
+    counter = 1
 
-	for nmobj in after_cons:
-		print
-		print " Connection %d: %s" % (counter, nmobj.get_uuid())
-		print " Connection state: %s" % nmobj.get_state()
-		print " get_devices():  %s" % nmobj.get_devices()
+    for nmobj in after_cons:
+    	print ()
+    	print (" Connection %d: %s" % (counter, nmobj.get_uuid()))
+    	print (" Connection state: %s" % nmobj.get_state())
+    	print (" get_devices():  %s" % nmobj.get_devices())
 
-		for device in nmobj.get_devices():
-			print "  Device: %s" % device.get_iface()
+    	for device in nmobj.get_devices():
+    		print ("  Device: %s" % device.get_iface())
 
-		counter += 1
+    	counter += 1
 
-	print
-	print "Sleeping for 3 seconds..."
-	time.sleep(3)
-	loop -= 1
+    print ()
+    print ("Sleeping for 3 seconds...")
+    time.sleep(3)
+    loop -= 1

--- a/version_control.py
+++ b/version_control.py
@@ -1,14 +1,16 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 from subprocess import call, check_output
 
-current_nm_version = "".join(check_output("""NetworkManager -V |awk 'BEGIN { FS = "." }; {printf "%03d%03d%03d", $1, $2, $3}'""", shell=True).split('-')[0])
+
+current_nm_version = "".join(check_output("""NetworkManager -V |awk 'BEGIN { FS = "." }; {printf "%03d%03d%03d", $1, $2, $3}'""", shell=True).decode('utf-8').split('-')[0])
 
 if "NetworkManager" in sys.argv[2] and "Test" in sys.argv[2]:
     test_name = "".join('_'.join(sys.argv[2].split('_')[2:]))
 else:
     test_name = sys.argv[2]
 
-raw_tags = check_output ("behave %s/features/  -k -t %s --dry-run |grep %s" %(sys.argv[1], test_name, test_name), shell=True)
+raw_tags = check_output ("behave %s/features/  -k -t %s --dry-run |grep %s" %(sys.argv[1], test_name, test_name), shell=True).decode('utf-8')
 tests_tags = raw_tags.split('\n')
 
 tag_to_return = ""


### PR DESCRIPTION
we need to make CI both python3 and python2 compatible for newer releases
* encoding fixes in pexpect and check_output 
* install python3 versions of apps
* import strings from futures to be unicode by default
* make exceptions python3 compatible
