### PR TITLE
ipv6: fix condition for ipv6_multiple_default_routes

### DIFF
--- a/nmcli/features/ipv6.feature
+++ b/nmcli/features/ipv6.feature
@@ -1470,4 +1470,4 @@
     * Execute "ip -6 addr add fe80::dead:dead:dead:dead/64 dev test10p"
     * Start radvd server with config from "tmp/radvd.conf"
     * Add a new connection of type "ethernet" and options "con-name con_ipv6 ifname test10 ipv6.may-fail no"
-    Then "2" is visible with command "ip -6 r |grep test10 | grep default |wc -l" in "60" seconds
+    Then "2" is visible with command "ip -6 r | grep default -A 3|grep "via fe80" |grep test10 |wc -l" in "60" seconds


### PR DESCRIPTION
New ip command interprets multiple default route slightly different
 than before. Use condition that suits both versions.