### PR TITLE
ipv4: split out client-id test for RHEL7

### DIFF
--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -239,6 +239,12 @@ def before_scenario(context, scenario):
             call("grep -q Maipo /etc/redhat-release", shell=True) != 0:
                 sys.exit(77)
 
+        if 'not_in_rhel7' in scenario.tags:
+            if call('rpm -qi NetworkManager |grep -q build.*bos.redhat.co', shell=True) == 0 and \
+            check_output("rpm --queryformat %{RELEASE} -q NetworkManager |awk -F .  '{ print ($1 < 200) }'", shell=True).decode('utf-8').strip() == '1' and \
+            call("grep -q Maipo /etc/redhat-release", shell=True) == 0:
+                sys.exit(77)
+
         if 'not_in_rhel' in scenario.tags:
             if call('rpm -qi NetworkManager |grep -q build.*bos.redhat.com', shell=True) == 0 or \
             check_output("rpm --queryformat %{RELEASE} -q NetworkManager |awk -F .  '{ print ($1 < 200) }'", shell=True).decode('utf-8').strip() == '1':

--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1179,9 +1179,9 @@ Feature: nmcli: ipv4
     Then "169.254" is visible with command "ip a s eth3" in "10" seconds
 
 
+    @ver-=1.11.1 @not_in_rhel7
     @eth2 @con_ipv4_remove
     @ipv4_dhcp_client_id_set
-    @ver-=1.11.1
     Scenario: nmcli - ipv4 - dhcp-client-id - set client id
     * Add connection type "ethernet" named "con_ipv4" for device "eth2"
     * Bring "up" connection "con_ipv4"
@@ -1200,7 +1200,7 @@ Feature: nmcli: ipv4
     Then "exceeds max \(255\) for precision" is not visible with command "grep exceeds max /var/log/messages"
 
 
-    @ver+=1.11.2
+    @ver+=1.11.2 @not_in_rhel7
     @eth2 @con_ipv4_remove @tcpdump
     @ipv4_dhcp_client_id_set
     # https://bugzilla.gnome.org/show_bug.cgi?id=793957
@@ -1221,6 +1221,27 @@ Feature: nmcli: ipv4
     * Bring "up" connection "con_ipv4"
     * Execute "sleep 5"
     Then "Client-ID Option 61, length 4: hardware-type 192, ff:ee:ee" is visible with command "cat /tmp/tcpdump.log"
+
+
+    @rhel7_only
+    @eth2 @con_ipv4_remove
+    @ipv4_dhcp_client_id_set
+    Scenario: nmcli - ipv4 - dhcp-client-id - set client id
+    * Add connection type "ethernet" named "con_ipv4" for device "eth2"
+    * Bring "up" connection "con_ipv4"
+    * Bring "down" connection "con_ipv4"
+    * Open editor for connection "con_ipv4"
+    * Submit "set ipv4.dhcp-client-id AB" in editor
+    * Save in editor
+    * Quit editor
+    * Run child "sudo tshark -l -O bootp -i eth2 -x > /tmp/tshark.log"
+    When "empty" is not visible with command "file /tmp/tshark.log" in "150" seconds
+    * Bring "up" connection "con_ipv4"
+    * Finish "sleep 5; sudo pkill tshark"
+    Then "AB" is visible with command "cat /tmp/tshark.log"
+    #Then "walderon" is visible with command "cat /var/lib/NetworkManager/dhclient-eth2.conf"
+    #VVV verify bug 999503
+    Then "exceeds max \(255\) for precision" is not visible with command "grep exceeds max /var/log/messages"
 
 
     @ver+=1.11.2


### PR DESCRIPTION
NM changed behavior upstream with respect to ascii-only
client-ids. Prior to 1.11.2 NM would send the client-id as is; since
1.11.2 the client-id is prefixed with a zero byte.

On RHEL7 (NM 1.12) we reverted the change to maintain the old behavior
and therefore we need to also adjust tests. We have now 3 instances of
the test:

 * RHEL7         (old behavior)
 * NM <  1.11.2  (old behavior)
 * NM >= 1.11.2  (new behavior)

(I have tried only the last two cases, not the first one).

https://bugzilla.redhat.com/show_bug.cgi?id=1613888