### PR TITLE
add 'nm_dhcp_lease_renewal_link_down' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -740,6 +740,8 @@ testmapper:
         feature: ipv4
     - ipv4_dhcp-hostname_shared_persists:
         feature: ipv4
+    - nm_dhcp_lease_renewal_link_down:
+        feature: ipv4
     - vlan_add_default_device:
         feature: vlan
     - vlan_add_beyond_range:


### PR DESCRIPTION
Add test, that if link is down during dhcp lease renewal and then comes back up, address is leased properly

https://bugzilla.redhat.com/show_bug.cgi?id=1573780

@Build:nm-1-12