### PR TITLE
pptp: add 'pptp_passwd_file' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1158,6 +1158,8 @@ testmapper:
         feature: adsl
     - pptp_add_profile:
         feature: pptp
+    - pptp_passwd_file:
+        feature: pptp        
     - pptp_terminate:
         feature: pptp
     - libreswan_add_profile:

--- a/nmcli/features/pptp.feature
+++ b/nmcli/features/pptp.feature
@@ -17,6 +17,23 @@
     Then "IP4.ADDRESS.*172.31.66.*/32" is visible with command "nmcli c show pptp"
 
 
+    @rhbz1628833
+    @pptp
+    @pptp_passwd_file
+    Scenario: nmcli - pptp - password from file
+    * Add a connection named "pptp" for device "\*" to "pptp" VPN
+    * Use user "budulinek" with password "file" and MPPE set to "yes" for gateway "127.0.0.1" on PPTP connection "pptp"
+    * Execute "echo 'vpn.secret.password:passwd' > /tmp/passwords"
+    * Execute "nmcli con up pptp passwd-file /tmp/passwords"
+    When "VPN.VPN-STATE:.*VPN connected" is visible with command "nmcli c show pptp"
+     And "IP4.ADDRESS.*172.31.66.*/32" is visible with command "nmcli c show pptp"
+    * Bring "down" connection "pptp"
+    * Execute "echo 'vpn.secrets.password:passwd' > /tmp/passwords"
+    * Execute "nmcli con up pptp passwd-file /tmp/passwords"
+    Then "VPN.VPN-STATE:.*VPN connected" is visible with command "nmcli c show pptp"
+     And "IP4.ADDRESS.*172.31.66.*/32" is visible with command "nmcli c show pptp"
+
+
     @pptp
     @pptp_terminate
     Scenario: nmcli - pptp - terminate connection

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -172,17 +172,21 @@ def set_vpnc_connection(context, user, password, group, secret, gateway, name):
     sleep(1)
 
 @step(u'Use user "{user}" with password "{password}" and MPPE set to "{mppe}" for gateway "{gateway}" on PPTP connection "{name}"')
-def set_vpnc_connection(context, user, password, mppe, gateway, name):
-    cli = pexpect.spawn('nmcli c modify %s vpn.data "password-flags = 0, user = %s, require-mppe = %s, gateway = %s"' % (name, user, mppe, gateway), encoding='utf-8')
+def set_pptp_connection(context, user, password, mppe, gateway, name):
+    flag = "0"
+    if password == "file":
+        flag = "2"
+    cli = pexpect.spawn('nmcli c modify %s vpn.data "password-flags = %s, user = %s, require-mppe = %s, gateway = %s"' % (name, flag, user, mppe, gateway), encoding='utf-8')
     r = cli.expect(['Error', pexpect.EOF])
     if r == 0:
         raise Exception('Got an Error while editing %s connection data' % (name))
     sleep(2)
-    cli = pexpect.spawn('nmcli c modify %s vpn.secrets "password = %s"' % (name, password), encoding='utf-8')
-    r = cli.expect(['Error', pexpect.EOF])
-    if r == 0:
-        raise Exception('Got an Error while editing %s connection secrets' % (name))
-    sleep(1)
+    if flag != "2":
+        cli = pexpect.spawn('nmcli c modify %s vpn.secrets "password = %s"' % (name, password), encoding='utf-8')
+        r = cli.expect(['Error', pexpect.EOF])
+        if r == 0:
+            raise Exception('Got an Error while editing %s connection secrets' % (name))
+        sleep(1)
 
 @step(u'Autocomplete "{cmd}" in bash and execute')
 def autocomplete_command(context, cmd):


### PR DESCRIPTION
NM can read passwords for VPNs from file. There was a bug in 1.12
 and we were only able to read vpn.secret but vpn.secrets was
supported before. We now support both versions to preserve backward
compatibility.

https://bugzilla.redhat.com/show_bug.cgi?id=1628946

@Build:nm-1-12