### PR TITLE
dns: add 'dns_dnsmasq_driver_removal' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1159,7 +1159,7 @@ testmapper:
     - pptp_add_profile:
         feature: pptp
     - pptp_passwd_file:
-        feature: pptp        
+        feature: pptp
     - pptp_terminate:
         feature: pptp
     - libreswan_add_profile:
@@ -1403,6 +1403,8 @@ testmapper:
     - dns_dnsmasq_full_tunnel_vpn:
         feature: dns
     - dns_dnsmasq_split_tunnel_vpn:
+        feature: dns
+    - dns_dnsmasq_driver_removal:
         feature: dns
     - nmtui_general_start_nmtui:
         run: nmtui/./runtest.sh nmtui_general_start_nmtui

--- a/nmcli/features/dns.feature
+++ b/nmcli/features/dns.feature
@@ -281,6 +281,31 @@ Feature: nmcli - dns
     Then device "eth3" has DNS domain "con_dns2.domain"
 
 
+    @rhbz1628576
+    @ver+=1.12
+    @con_dns_remove @dns_dnsmasq @regenerate_veth @teardown_testveth @skip_str
+    @dns_dnsmasq_driver_removal
+    Scenario: NM - dns - remove driver
+    * Prepare simulated test "testX4" device
+
+    # Create connection on testX4 with default route
+    * Add a new connection of type "ethernet" and options "con-name con_dns ifname testX4 autoconnect no"
+    * Execute "nmcli connection modify con_dns ipv4.method manual ipv4.addresses 172.16.1.1/24 ipv4.gateway 172.16.1.2"
+    * Execute "nmcli connection modify con_dns ipv4.dns 172.16.1.53 ipv4.dns-search con_dns.domain"
+    * Bring "up" connection "con_dns"
+
+    # Check testX4 configuration
+    Then device "testX4" has DNS server "172.16.1.53"
+    Then device "testX4" has DNS domain "."
+    Then device "testX4" has DNS domain "con_dns.domain"
+
+    # Unload veth Driver
+    * Execute "modprobe -r veth"
+
+    # NM should still be working
+    * Bring "up" connection "testeth0"
+
+
     @rhbz1512966
     @ver+=1.11.3
     @con_dns_remove @dns_dnsmasq

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -1049,11 +1049,6 @@ def after_scenario(context, scenario):
             print ("deleting connection con_ethernet")
             call("nmcli connection delete id con_ethernet", shell=True)
 
-        if 'con_dns_remove' in scenario.tags:
-            print ("---------------------------")
-            print ("deleting connection con_dns and con_dns2")
-            call("nmcli connection delete id con_dns con_dns2 ", shell=True)
-
         if 'alias' in scenario.tags:
             print ("---------------------------")
             print ("deleting alias connections")


### PR DESCRIPTION
Check that NM doesn't crash when veth driver is removed after con
is up with dns=dnsmasq settings enabled.

https://bugzilla.redhat.com/show_bug.cgi?id=1628576

@Build:nm-1-12