### PR TITLE
FIX: run_once_ip6_renewal

### DIFF
--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -967,7 +967,6 @@ Feature: nmcli - general
     * Start NM
     When "2620:" is visible with command "ip a s testG" in "60" seconds
     * Force renew IPv6 for "testG"
-    When "2620:" is not visible with command "ip a s testG"
     Then "2620:" is visible with command "ip a s testG" in "120" seconds
 
 

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -976,10 +976,9 @@ def flag_cap_set(context, flag, n=None, device='wlan0', giveexception=True):
 
 @step(u'Force renew IPv6 for "{device}"')
 def force_renew_ipv6(context, device):
-    mac = command_output(context, "ip a s %s |grep fe80 |awk '{print $2}'" % device)
-    command_code(context, "echo 1 >  /proc/sys/net/ipv6/conf/%s/disable_ipv6" % device)
-    command_code(context, "echo 0 >  /proc/sys/net/ipv6/conf/%s/disable_ipv6" % device)
-    command_code(context, "ip addr add %s dev %s" %(mac, device))
+    mac = command_output(context, "ip a s %s |grep fe80 |awk '{print $2}'" % device).strip()
+    command_code(context, "ip -6 addr flush dev %s" % (device))
+    command_code(context, "ip addr add %s dev %s" % (mac, device))
 
 
 @step(u'Global temporary ip is not based on mac of device "{dev}"')


### PR DESCRIPTION
FIX '* Force renew IPv6 for "testG"' step:
 * captured ipv6 included newline causing problems
 * use "ip flush" to remove old address (no need to check that address is deleted afterwards)