### PR TITLE
Add 'libreswan_reimport' test using IKEv2

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1205,6 +1205,8 @@ testmapper:
         feature: libreswan
     - libreswan_activate_asking_for_password_and_secret:
         feature: libreswan
+    - libreswan_reimport:
+        feature: libreswan
     - vpn_describe:
         feature: vpn
     - multiple_vpn_connections:

--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1207,6 +1207,8 @@ testmapper:
         feature: libreswan
     - libreswan_reimport:
         feature: libreswan
+    - libreswan_configurable_options_reimport:
+        feature: libreswan
     - vpn_describe:
         feature: vpn
     - multiple_vpn_connections:

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -96,10 +96,10 @@ def reset_usb_devices():
             print(("failed to reset device:", msg))
         f.close()
 
-def setup_libreswan(mode, dh_group, phase1_al="aes", phase2_al=None):
+def setup_libreswan(mode, dh_group, phase1_al="aes", phase2_al=None, ike="ikev1"):
     print ("setting up libreswan")
 
-    RC = call("sh prepare/libreswan.sh %s %s %s" %(mode, dh_group, phase1_al), shell=True)
+    RC = call("sh prepare/libreswan.sh %s %s %s %s" %(mode, dh_group, phase1_al, ike), shell=True)
     if RC != 0:
         teardown_libreswan()
         sys.exit(1)
@@ -707,14 +707,20 @@ def before_scenario(context, scenario):
             wait_for_testeth0()
             call("rpm -q NetworkManager-libreswan || ( sudo yum -y install NetworkManager-libreswan && systemctl restart NetworkManager )", shell=True)
             call("/usr/sbin/ipsec --checknss", shell=True)
-            setup_libreswan (mode="aggressive", dh_group=5)
+            ike="ikev1"
+            if 'ikev2' in scenario.tags:
+                ike="ikev2"
+            setup_libreswan (mode="aggressive", dh_group=5, ike=ike)
 
         if 'libreswan_main' in scenario.tags:
             print ("---------------------------")
             wait_for_testeth0()
             call("rpm -q NetworkManager-libreswan || sudo yum -y install NetworkManager-libreswan", shell=True)
             call("/usr/sbin/ipsec --checknss", shell=True)
-            setup_libreswan (mode="main", dh_group=5)
+            ike="ikev1"
+            if 'ikev2' in scenario.tags:
+                ike="ikev2"
+            setup_libreswan (mode="main", dh_group=5, ike=ike)
 
         if 'macsec' in scenario.tags:
             print("---------------------------")

--- a/nmcli/features/libreswan.feature
+++ b/nmcli/features/libreswan.feature
@@ -282,3 +282,17 @@
     When Check noted values "vpn1" and "vpn2" are the same
     * Connect to vpn "libreswan" with password "passwd" and secret "ipsecret"
     Then "VPN.VPN-STATE:.*VPN connected" is visible with command "nmcli c show libreswan"
+
+
+    @rhbz1557035
+    @ver+=1.14.0
+    @vpn @not_in_rhel7
+    @libreswan_configurable_options_reimport
+    Scenario: nmcli - libreswan - check libreswan options in vpn.data
+    * Add a new connection of type "vpn" and options "ifname \* con-name vpn autoconnect no vpn-type libreswan vpn.data 'right=1.2.3.4, rightid=server, rightrsasigkey=server-key, left=1.2.3.5, leftid=client, leftrsasigkey=client-key, leftcert=client-cert, ike=aes256-sha1;modp1536, esp=aes256-sha1, ikelifetime=10m, salifetime=1h, vendor=Cisco, rightsubnet=1.2.3.0/24, ikev2=yes, narrowing=yes, rekey=no, fragmentation=no'"
+    * Note the output of "nmcli -t -f vpn.data connection show vpn | sed -e 's/vpn.data:\s*//' | sed -e 's/\s*,\s*/\n/g' | sort" as value "vpn1"
+    * Execute "nmcli connection export vpn > /tmp/vpn.swan"
+    * Delete connection "vpn"
+    * Execute "nmcli con import file /tmp/vpn.swan type libreswan"
+    * Note the output of "nmcli -t -f vpn.data connection show vpn | sed -e 's/vpn.data:\s*//' | sed -e 's/\s*,\s*/\n/g' | sort" as value "vpn2"
+    Then Check noted values "vpn1" and "vpn2" are the same

--- a/nmcli/features/libreswan.feature
+++ b/nmcli/features/libreswan.feature
@@ -253,8 +253,32 @@
     @vpn
     @libreswan_autocompletion
     Scenario: nmcli - libreswan - autocompletion
-     * "file.*type" is visible with tab after "nmcli con import "
-     Then "vpn.swan" is visible with tab after "nmcli con import file tmp/"
-      And "vpn.swan" is visible with tab after "nmcli con import type libreswan file tmp/"
-      And "type" is visible with tab after "nmcli con import file tmp/vpn.swan "
-      And "libreswan|openswan|openconnect|strongswan" is visible with tab after "nmcli con import file tmp/vpn.swan type "
+    * "file.*type" is visible with tab after "nmcli con import "
+    Then "vpn.swan" is visible with tab after "nmcli con import file tmp/"
+     And "vpn.swan" is visible with tab after "nmcli con import type libreswan file tmp/"
+     And "type" is visible with tab after "nmcli con import file tmp/vpn.swan "
+     And "libreswan|openswan|openconnect|strongswan" is visible with tab after "nmcli con import file tmp/vpn.swan type "
+
+
+    @rhbz1633174
+    @ver+=1.14.0
+    @libreswan @ikev2 @rhel8_only
+    @libreswan_reimport
+    Scenario: nmcli - libreswan - reimport exported connection
+    * Add a new connection of type "vpn" and options "ifname \* con-name libreswan autoconnect no vpn-type libreswan"
+    * Use user "budulinek" with password "ask" and group "yolo" with secret "ask" for gateway "172.31.70.1" on Libreswan connection "libreswan"
+    * Modify connection "libreswan" changing options "+vpn.data ikev2=insist"
+    * Connect to vpn "libreswan" with password "passwd" and secret "ipsecret"
+    When "VPN.VPN-STATE:.*VPN connected" is visible with command "nmcli c show libreswan"
+    # options in vpn.data may be in arbitrary order, sort them so it is comparable
+    * Note the output of "nmcli -t -f vpn.data connection show libreswan | sed -e 's/vpn.data:\s*//' | sed -e 's/\s*,\s*/\n/g' | sort" as value "vpn1"
+    * Execute "nmcli connection export libreswan > /tmp/vpn.swan"
+    * Bring "down" connection "libreswan"
+    * Delete connection "libreswan"
+    * Execute "nmcli con import file /tmp/vpn.swan type libreswan"
+    # add required options, which are not exported
+    * Modify connection "libreswan" changing options "+vpn.data pskinputmodes=ask,xauthpasswordinputmodes=ask,pskvalue-flags=2,xauthpassword-flags=2,leftxauthusername=budulinek"
+    * Note the output of "nmcli -t -f vpn.data connection show libreswan | sed -e 's/vpn.data:\s*//' | sed -e 's/\s*,\s*/\n/g' | sort" as value "vpn2"
+    When Check noted values "vpn1" and "vpn2" are the same
+    * Connect to vpn "libreswan" with password "passwd" and secret "ipsecret"
+    Then "VPN.VPN-STATE:.*VPN connected" is visible with command "nmcli c show libreswan"

--- a/prepare/libreswan.sh
+++ b/prepare/libreswan.sh
@@ -21,119 +21,125 @@ kill_dnsmasq() {
 
 libreswan_gen_connection ()
 {
-	CONNECTION_CFG="$1"
-	MODE="$2"
+    CONNECTION_CFG="$1"
+    MODE="$2"
+    IKEv2="$3"
 
-	echo "conn roadwarrior_psk
-	auto=add
-	authby=secret
-	pfs=no
-	rekey=no
-	left=172.31.70.1
-	leftsubnet=0.0.0.0/0
-	rightaddresspool=172.29.100.2-172.29.100.10
-	right=%any
-	cisco-unity=yes
-	leftxauthserver=yes
-	rightxauthclient=yes
-	leftmodecfgserver=yes
-	rightmodecfgclient=yes
-	modecfgpull=yes
+    echo "conn roadwarrior_psk
+    auto=add
+    authby=secret
+    pfs=no
+    rekey=no
+    left=172.31.70.1
+    leftsubnet=0.0.0.0/0
+    rightaddresspool=172.29.100.2-172.29.100.10
+    right=%any
+    cisco-unity=yes
+    leftxauthserver=yes
+    rightxauthclient=yes
+    leftmodecfgserver=yes
+    rightmodecfgclient=yes
+    modecfgpull=yes
     modecfgdns1=8.8.8.8
     modecfgbanner=BUG_REPORT_URL
-	xauthby=alwaysok
-	ike-frag=yes
-	ikev2=never" > "$CONNECTION_CFG"
-	if [ "$MODE" = "aggressive" ]; then
-		echo \
-"	rightid=@yolo
-	aggressive=yes" >> "$CONNECTION_CFG"
-	fi
+    xauthby=alwaysok
+    ike-frag=yes
+    ikev2=$IKEv2" > "$CONNECTION_CFG"
+    if [ "$MODE" = "aggressive" ]; then
+        echo \
+"   rightid=@yolo
+    aggressive=yes" >> "$CONNECTION_CFG"
+    fi
+
 }
 
 libreswan_gen_secrets ()
 {
-	SECRETS_CFG="$1"
+    SECRETS_CFG="$1"
 
-	echo ": PSK \"ipsecret\"" > "$SECRETS_CFG"
-	chmod 600 "$SECRETS_CFG"
+    echo ": PSK \"ipsecret\"" > "$SECRETS_CFG"
+    chmod 600 "$SECRETS_CFG"
 }
 
 libreswan_gen_netconfig ()
 {
-	ip netns add libreswan
+    ip netns add libreswan
 
-	# IPv6 on a veth confuses pluto. Sigh. (TODO: check id still true)
-	# ERROR: bind() for 80/80 fe80::94bf:8cff:fe1b:7620:500 in process_raw_ifaces(). Errno 22: Invalid argument
-	echo 1 > /proc/sys/net/ipv6/conf/default/disable_ipv6
-	ip netns exec libreswan echo 1 > /proc/sys/net/ipv6/conf/default/disable_ipv6
-	ip link add libreswan0 type veth peer name libreswan1
-	ip link set libreswan0 netns libreswan
+    # IPv6 on a veth confuses pluto. Sigh. (TODO: check id still true)
+    # ERROR: bind() for 80/80 fe80::94bf:8cff:fe1b:7620:500 in process_raw_ifaces(). Errno 22: Invalid argument
+    echo 1 > /proc/sys/net/ipv6/conf/default/disable_ipv6
+    ip netns exec libreswan echo 1 > /proc/sys/net/ipv6/conf/default/disable_ipv6
+    ip link add libreswan0 type veth peer name libreswan1
+    ip link set libreswan0 netns libreswan
 
-	ip netns exec libreswan ip link set lo up
-	ip netns exec libreswan ip addr add dev libreswan0 172.31.70.1/24
-	ip netns exec libreswan ip link set libreswan0 up
-	ip link set dev libreswan1 up
+    ip netns exec libreswan ip link set lo up
+    ip netns exec libreswan ip addr add dev libreswan0 172.31.70.1/24
+    ip netns exec libreswan ip link set libreswan0 up
+    ip link set dev libreswan1 up
 
-	ip netns exec libreswan dnsmasq --pid-file=/tmp/libreswan_dnsmasq.pid \
-	                                --dhcp-range=172.31.70.2,172.31.70.40,2m \
-	                                --interface=libreswan0 --bind-interfaces
-	echo "PID of dnsmasq:"
-	cat /tmp/libreswan_dnsmasq.pid
+    ip netns exec libreswan dnsmasq --pid-file=/tmp/libreswan_dnsmasq.pid \
+                                    --dhcp-range=172.31.70.2,172.31.70.40,2m \
+                                    --interface=libreswan0 --bind-interfaces
+    echo "PID of dnsmasq:"
+    cat /tmp/libreswan_dnsmasq.pid
 }
 
 ####
 
 libreswan_setup ()
 {
-	# Quit immediatelly on any script error
-	set -e
-	MODE="$1"
-	CONNECTION_CFG="$LIBRESWAN_DIR/connection.conf"
-	SECRETS_CFG="$LIBRESWAN_DIR/ipsec.secrets"
-	NSS_DIR="$LIBRESWAN_DIR/nss"
+    # Quit immediatelly on any script error
+    set -e
+    MODE="$1"
+    CONNECTION_CFG="$LIBRESWAN_DIR/connection.conf"
+    SECRETS_CFG="$LIBRESWAN_DIR/ipsec.secrets"
+    NSS_DIR="$LIBRESWAN_DIR/nss"
+    if [ "$4" = "ikev2" ]; then
+        IKEv2="insist"
+    else
+        IKEv2="never"
+    fi
+    echo "Configuring remote Libreswan peer"
+    [ -d "$LIBRESWAN_DIR" ] || mkdir "$LIBRESWAN_DIR"
+    [ -d "$NSS_DIR" ] || mkdir "$NSS_DIR"
 
-	echo "Configuring remote Libreswan peer"
-	[ -d "$LIBRESWAN_DIR" ] || mkdir "$LIBRESWAN_DIR"
-	[ -d "$NSS_DIR" ] || mkdir "$NSS_DIR"
+    libreswan_gen_secrets "$SECRETS_CFG"
+    libreswan_gen_connection "$CONNECTION_CFG" "$MODE" "$IKEv2"
+    libreswan_gen_netconfig
 
-	libreswan_gen_secrets "$SECRETS_CFG"
-	libreswan_gen_connection "$CONNECTION_CFG" "$MODE"
-	libreswan_gen_netconfig
+    ### add default route connection that takes precedence over the system one
+    nmcli connection add type ethernet con-name lib1 ifname libreswan1 autoconnect no \
+        ipv6.method ignore ipv4.route-metric 90
+    # Warning: the next command interrupts any established SSH connection to the remote machine!
+    nmcli connection up id lib1
 
-	### add default route connection that takes precedence over the system one
-	nmcli connection add type ethernet con-name lib1 ifname libreswan1 autoconnect no \
-		ipv6.method ignore ipv4.route-metric 90
-	# Warning: the next command interrupts any established SSH connection to the remote machine!
-	nmcli connection up id lib1
+    set +e
 
-	set +e
-
-	modprobe af_key
-	ipsec checknss --nssdir "$NSS_DIR"
+    modprobe af_key
+    ipsec checknss --nssdir "$NSS_DIR"
 
     ip netns exec libreswan ipsec pluto \
-				--secretsfile "$SECRETS_CFG" \
-				--ipsecdir "$LIBRESWAN_DIR" \
-				--nssdir "$NSS_DIR" \
-				--rundir "$LIBRESWAN_DIR"
-	ipsec addconn --addall --config "$CONNECTION_CFG" --ctlsocket "$LIBRESWAN_DIR/pluto.ctl"
+                --secretsfile "$SECRETS_CFG" \
+                --ipsecdir "$LIBRESWAN_DIR" \
+                --nssdir "$NSS_DIR" \
+                --rundir "$LIBRESWAN_DIR"
+    ipsec addconn --addall --config "$CONNECTION_CFG" --ctlsocket "$LIBRESWAN_DIR/pluto.ctl"
 
 }
 
 libreswan_teardown ()
 {
-	kill $(cat "$LIBRESWAN_DIR/pluto.pid")
-	echo 0 > /proc/sys/net/ipv6/conf/default/disable_ipv6
-	ip netns del libreswan
-	ip link del libreswan1
-	kill_dnsmasq
-	nmcli connection del lib1
-	modprobe -r ip_vti
+    kill $(cat "$LIBRESWAN_DIR/pluto.pid")
+    echo 0 > /proc/sys/net/ipv6/conf/default/disable_ipv6
+    ip netns del libreswan
+    ip link del libreswan1
+    kill_dnsmasq
+    nmcli connection del lib1
+    modprobe -r ip_vti
 }
 
 if [ "$1" != "teardown" ]; then
-	libreswan_setup $1 $2 $3
+    libreswan_setup $1 $2 $3 $4
 else
-	libreswan_teardown
+    libreswan_teardown
 fi


### PR DESCRIPTION
test that reimporting exported connection does not drop options

test is using IKEv2 - modified prepare script to accept IKE version as argument

FIX: retab prepare/libreswan.sh file

ADD: dummy test 'libreswan_onfigurable_options'

https://bugzilla.redhat.com/show_bug.cgi?id=1633174
@Build:nm-1-14