### PR TITLE
add "connection_prefers_managed_devices" and "connection_no_managed_d…

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1331,6 +1331,10 @@ testmapper:
         feature: connection
     - connection_multiconnect_reboot:
         feature: connection
+    - connection_prefers_managed_devices:
+        feature: connection
+    - connection_no_managed_device:
+        feature: connection
     - add_default_tap_device:
         feature: tuntap
     - add_default_tun_device:

--- a/nmcli/features/connection.feature
+++ b/nmcli/features/connection.feature
@@ -716,3 +716,24 @@ Feature: nmcli: connection
      And "eth8" is visible with command "nmcli device | grep ethernet | grep con_con"
      And "eth9" is visible with command "nmcli device | grep ethernet | grep con_con"
      And "eth10" is visible with command "nmcli device | grep ethernet | grep con_con"
+
+
+     @rhbz1639254
+     @ver+=1.14
+     @con_con_remove @unmanage_eth @skip_str
+     @connection_prefers_managed_devices
+     Scenario: nmcli - connection - connection activates preferably on managed devices
+      * Execute "nmcli device set eth10 managed yes"
+      * Add a new connection of type "ethernet" and options "ifname \* con-name con_con autoconnect no"
+      * Bring up connection "con_con"
+      Then "eth10" is visible with command "nmcli device | grep con_con"
+
+
+      @rhbz1639254
+      @ver+=1.14
+      @con_con_remove @unmanage_eth @skip_str
+      @connection_no_managed_device
+      Scenario: nmcli - connection - connection activates even on unmanaged device
+       * Add a new connection of type "ethernet" and options "ifname \* con-name con_con autoconnect no"
+       * Bring up connection "con_con"
+       Then "con_con" is visible with command "nmcli device"

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -395,6 +395,10 @@ def before_scenario(context, scenario):
                             raise Exception("Timeout reached!")
                         continue
 
+        if 'unmanage_eth' in scenario.tags:
+            for link in range(0,11):
+                call('nmcli dev set eth%d managed no' % link, shell=True)
+
         if 'connectivity' in scenario.tags:
             print ("---------------------------")
             print ("add connectivity checker")
@@ -403,7 +407,6 @@ def before_scenario(context, scenario):
             call("echo 'response=OK' >> /etc/NetworkManager/conf.d/99-connectivity.conf", shell=True)
             call("echo 'interval=10' >> /etc/NetworkManager/conf.d/99-connectivity.conf", shell=True)
             reload_NM_service()
-
 
         if 'shutdown_service_any' in scenario.tags or 'bridge_manipulation_with_1000_slaves' in scenario.tags:
             call("modprobe -r qmi_wwan", shell=True)
@@ -1942,14 +1945,19 @@ def after_scenario(context, scenario):
                 print("WORKAROUND for permissive selinux")
                 call('setenforce 1', shell=True)
 
+        if 'unmanage_eth' in scenario.tags:
+            for link in range(0,11):
+                call('nmcli dev set eth%d managed yes' % link, shell=True)
+
         if 'regenerate_veth' in scenario.tags or 'restart' in scenario.tags:
             print ("---------------------------")
             print ("regenerate veth setup")
             if os.path.isfile('/tmp/nm_newveth_configured'):
                 call('sh prepare/vethsetup.sh check', shell=True)
             else:
-                for link in range(1,10):
+                for link in range(1,11):
                     call('ip link set eth%d up' % link, shell=True)
+
 
 
         dump_status(context, 'after cleanup %s' % scenario.name)


### PR DESCRIPTION
…evice" test

Add test, that managed devices have higher priority than unmanaged, and 
that if there is no managed device, NM picks unmanaged one and activates 
it.

small FIX: restart tag - fix eth range

https://bugzilla.redhat.com/show_bug.cgi?id=1639254

@Build:nm-1-14