### PR TITLE
add 'ipv4_dhcp_client_id_change_lease_restart' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -753,6 +753,8 @@ testmapper:
         feature: ipv4
     - nm_dhcp_lease_renewal_link_down:
         feature: ipv4
+    - ipv4_dhcp_client_id_change_lease_restart:
+        feature: ipv4
     - vlan_add_default_device:
         feature: vlan
     - vlan_add_beyond_range:


### PR DESCRIPTION
Add test, that client-id is not read from lease file after NM restart

https://bugzilla.redhat.com/show_bug.cgi?id=1642023

@Build:nm-1-14