### PR TITLE
add 'nm_dhcp_client_id_default_settings' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -743,6 +743,8 @@ testmapper:
         feature: ipv4
     - ipv4_dhcp_do_not_add_route_to_server:
         feature: ipv4
+    - nm_dhcp_client_id_default_settings:
+        feature: ipv4
     - ipv4_keep_external_addresses:
         feature: ipv4
     - ipv4_route_onsite:

--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -2047,3 +2047,12 @@ Feature: nmcli: ipv4
     * Wait for at least "10" seconds
     * Execute "ip netns exec testX4_ns kill -SIGCONT $(cat /tmp/testX4_ns.pid)"
     Then "IP4.ADDRESS" is visible with command "nmcli -f ip4.address device show testX4" in "10" seconds
+
+
+    @rhbz1640494
+    @ver+=1.14
+    @rhel8_only
+    @nm_dhcp_client_id_default_settings
+    Scenario: NM - ipv4 - check default NM setting regarging DHCP client-id
+    Then "match-device=except:dhcp-plugin:dhclient" is visible with command "NetworkManager --print-config"
+     And "ipv4.dhcp-client-id=mac" is visible with command "NetworkManager --print-config"


### PR DESCRIPTION
Add test, that NM has right settings regarding DHCP client-id in RHEL8

https://bugzilla.redhat.com/show_bug.cgi?id=1640494