### PR TITLE
FIX: 'libreswan_configurable_options_reimport' test tag

### DIFF
--- a/nmcli/features/libreswan.feature
+++ b/nmcli/features/libreswan.feature
@@ -262,7 +262,7 @@
 
     @rhbz1633174
     @ver+=1.14.0
-    @libreswan @ikev2 @rhel8_only
+    @libreswan @ikev2 @not_in_rhel7
     @libreswan_reimport
     Scenario: nmcli - libreswan - reimport exported connection
     * Add a new connection of type "vpn" and options "ifname \* con-name libreswan autoconnect no vpn-type libreswan"


### PR DESCRIPTION
rhel8_only tag caused skipping, replaced by not_in_rhel7
the purpose of this is that RHEL7 have old version of libreswan plugin, 
so the test would fail