### PR TITLE
add "libnm_async_activation_cancellable_no_crash" test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1123,6 +1123,8 @@ testmapper:
         feature: general
     - libnm_async_tasks_cancelable:
         feature: general
+    - libnm_async_activation_cancelable_no_crash:
+        feature: general
     - nmcli_monitor_assertion_con_up_down:
         feature: general
     - libnm_snapshot_rollback:

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1751,12 +1751,20 @@ Feature: nmcli - general
     Then Finish "python tmp/repro_1555281.py con_general"
 
 
+    @rhbz1643085 @rhbz1642625
+    @ver+=1.14
+    @con_general_remove
+    @libnm_async_activation_cancelable_no_crash
+    Scenario: NM - general - cancelation of libnm async activation - should not crash
+    Then Finish "python tmp/repro_1643085.py con_general eth8"
+
+
     @rhbz1614691
     @ver+=1.12
     @con_general_remove
     @nmcli_monitor_assertion_con_up_down
     Scenario: NM - general - nmcli monitor asserts error when connection is activated or deactivated
-    * Add connection type "ethernet" named "con_general" for device "eth2"
+    * Add connection type "ethernet" named "con_general" for device "eth8"
     * Execute "nmcli monitor &> /tmp/nmcli_monitor_out & pid=$!; sleep 10; kill $pid" without waiting for process to finish
     * Bring "up" connection "con_general"
     * Wait for at least "1" seconds

--- a/tmp/repro_1643085.py
+++ b/tmp/repro_1643085.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+# all credits to Gris Ge https://bugzilla.redhat.com/show_bug.cgi?id=1642625#c11
+from subprocess import check_call
+import sys
+
+import gi
+gi.require_version('NM', '1.0')
+from gi.repository import Gio, GLib, NM
+
+
+
+nmclient = NM.Client.new()
+
+conn_name = sys.argv[1]
+conn_ifname = sys.argv[2]
+
+conn = nmclient.get_connection_by_id(conn_name)
+
+if not conn:
+    check_call([ 'nmcli', 'c', 'add', 'type', 'ethernet', 'ifname', conn_ifname,
+                 'connection.id', conn_name])
+    nmclient = NM.Client.new()
+    conn = nmclient.get_connection_by_id('con_general')
+    if not conn:
+        print("Failed to find newly created connection")
+        exit()
+
+cancellable = Gio.Cancellable.new()
+mainloop = GLib.MainLoop()
+
+user_data = cancellable
+
+def _active_connection_callback(src_object, result, user_data):
+    user_data.cancel()
+    mainloop.quit()
+
+nmclient.activate_connection_async(conn, None, None, cancellable,
+                                   _active_connection_callback, user_data)
+
+mainloop.run()


### PR DESCRIPTION
use reproducer from Gris Ge 
https://bugzilla.redhat.com/show_bug.cgi?id=1642625#c11 

https://bugzilla.redhat.com/show_bug.cgi?id=1643085

FIX: nmcli_monitor_assertion_con_up_down uses eth2 instead of eth8

@Build:nm-1-14