### PR TITLE
add 'bridge_detect_initrd_device' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -286,6 +286,8 @@ testmapper:
         feature: bridge
     - bridge_ipv6:
         feature: bridge
+    - bridge_detect_initrd_device:
+        feature: bridge
     - add_default_team:
         feature: team
     - add_default_team_after_journal_restart:

--- a/nmcli/features/bridge.feature
+++ b/nmcli/features/bridge.feature
@@ -541,3 +541,23 @@ Feature: nmcli - bridge
     * Bring "up" connection "bridge-slave-eth4"
     Then "fe80" is visible with command "ip a show dev bridge0" in "20" seconds
      And "fd01:42::1/64" is visible with command "ip a show dev bridge0" in "20" seconds
+
+
+    @rhbz1593939
+    @ver+=1.14
+    @restart @bridge
+    @bridge_detect_initrd_device
+    Scenario: NM - bridge - nm detects initrd bridge
+    * Add a new connection of type "bridge" and options "con-name bridge0 ifname bridge0 bridge.stp no"
+    * Add a new connection of type "ethernet" and options "con-name bridge-slave-eth4 ifname eth4 master bridge0"
+    * "." is visible with command "nmcli -g IP4.ADDRESS  c s bridge0" in "10" seconds
+    * Stop NM
+    * Execute "ip link set br0 type bridge forward_delay 0"
+    * Execute "ip link set eth4 type bridge_slave cost 4"
+    * Wait for at least "2" seconds
+    * Reboot
+    * Start NM
+    * Wait for at least "2" seconds
+    Then "1" is visible with command "nmcli connection | grep '^bridge-slave-eth4' | wc -l"
+     And "1" is visible with command "nmcli connection | grep '^bridge0' | wc -l"
+     And "\neth4" is not visible with command "nmcli connection show"


### PR DESCRIPTION
Add test, that devices created by initrd are mapped to existing 
connections, NM should not create temporary connection, even if device
parameters slightly differ.

https://bugzilla.redhat.com/show_bug.cgi?id=1593939

@Build:nm-1-14