### PR TITLE
add "static_route_persists_mac_change" test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -819,6 +819,8 @@ testmapper:
         feature: vlan
     - vlan_on_bond_autoconnect:
         feature: vlan
+    - static_route_persists_mac_change:
+        feature: vlan
     - ethernet_create_with_editor:
         feature: ethernet
     - ethernet_create_default_connection:


### PR DESCRIPTION
Add test, that NM does not delete static route when changing MAC address 
of the device.

Thanks @thaller for reproducer:
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/merge_requests/54#note_82187

https://bugzilla.redhat.com/show_bug.cgi?id=1659063

@Build:nm-1-14