### PR TITLE
add 'ipv4_dhcp_client_id_mac_default' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -680,6 +680,12 @@ testmapper:
         feature: ipv4
     - ipv4_set_very_long_dhcp_client_id:
         feature: ipv4
+    - ipv4_dhcp_client_id_default:
+        feature: ipv4
+    - ipv4_dhcp_client_id_default_rhel7:
+        feature: ipv4
+    - ipv4_dhcp_client_id_default_rhel8:
+        feature: ipv4
     - ipv4_may-fail_yes:
         feature: ipv4
     - ipv4_method_disabled:

--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1330,7 +1330,7 @@ Feature: nmcli: ipv4
 
     @rhbz1661165
     @ver+=1.15.1 @not_in_rhel
-    @internal_DHCP @con_ipv4_remove @tcpdump
+    @internal_DHCP @con_ipv4_remove @tcpdump @no_config_server
     @ipv4_dhcp_client_id_default
     Scenario: NM - ipv4 - ipv4 client id should default to mac with internal plugins
     * Add connection type "ethernet" named "con_ipv4" for device "eth2"
@@ -1344,7 +1344,7 @@ Feature: nmcli: ipv4
 
     @rhbz1661165
     @ver+=1.12 @ver-=1.15 @not_in_rhel
-    @internal_DHCP @con_ipv4_remove @tcpdump
+    @internal_DHCP @con_ipv4_remove @tcpdump @no_config_server
     @ipv4_dhcp_client_id_default
     Scenario: NM - ipv4 - ipv4 client id should default to duid with internal plugins
     * Add connection type "ethernet" named "con_ipv4" for device "eth2"
@@ -1357,7 +1357,7 @@ Feature: nmcli: ipv4
 
     @rhbz1661165
     @rhel8_only
-    @internal_DHCP @con_ipv4_remove @tcpdump
+    @internal_DHCP @con_ipv4_remove @tcpdump @no_config_server
     @ipv4_dhcp_client_id_default_rhel8
     Scenario: NM - ipv4 - ipv4 client id should default to mac with internal plugins
     * Add connection type "ethernet" named "con_ipv4" for device "eth2"
@@ -1371,7 +1371,7 @@ Feature: nmcli: ipv4
 
     @rhbz1661165
     @rhel7_only
-    @internal_DHCP @con_ipv4_remove @tcpdump
+    @internal_DHCP @con_ipv4_remove @tcpdump @no_config_server
     @ipv4_dhcp_client_id_default_rhel7
     Scenario: NM - ipv4 - ipv4 client id should default to duid with internal plugins
     * Add connection type "ethernet" named "con_ipv4" for device "eth2"

--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1343,7 +1343,7 @@ Feature: nmcli: ipv4
 
 
     @rhbz1661165
-    @ver+=1.12 @ver-=1.14 @not_in_rhel
+    @ver+=1.12 @ver-=1.15 @not_in_rhel
     @internal_DHCP @con_ipv4_remove @tcpdump
     @ipv4_dhcp_client_id_default
     Scenario: NM - ipv4 - ipv4 client id should default to duid with internal plugins

--- a/nmcli/features/ipv4.feature
+++ b/nmcli/features/ipv4.feature
@@ -1328,6 +1328,60 @@ Feature: nmcli: ipv4
     Then Bring "up" connection "con_ipv4"
 
 
+    @rhbz1661165
+    @ver+=1.15.1 @not_in_rhel
+    @internal_DHCP @con_ipv4_remove @tcpdump
+    @ipv4_dhcp_client_id_default
+    Scenario: NM - ipv4 - ipv4 client id should default to mac with internal plugins
+    * Add connection type "ethernet" named "con_ipv4" for device "eth2"
+    * Note MAC address output for device "eth2" via ip command
+    * Run child "sudo tcpdump -i eth2 -v -n > /tmp/tcpdump.log"
+    * Bring "up" connection "con_ipv4"
+    When "empty" is not visible with command "file /tmp/tcpdump.log" in "150" seconds
+    * Bring "up" connection "con_ipv4"
+    Then Noted value is visible with command "grep 'Option 61' /tmp/tcpdump.log" in "10" seconds
+
+
+    @rhbz1661165
+    @ver+=1.12 @ver-=1.14 @not_in_rhel
+    @internal_DHCP @con_ipv4_remove @tcpdump
+    @ipv4_dhcp_client_id_default
+    Scenario: NM - ipv4 - ipv4 client id should default to duid with internal plugins
+    * Add connection type "ethernet" named "con_ipv4" for device "eth2"
+    * Run child "sudo tcpdump -i eth2 -v -n > /tmp/tcpdump.log"
+    * Bring "up" connection "con_ipv4"
+    When "empty" is not visible with command "file /tmp/tcpdump.log" in "150" seconds
+    * Bring "up" connection "con_ipv4"
+    Then "00:02:00:00:ab:11" is visible with command "grep 'Option 61' /tmp/tcpdump.log" in "10" seconds
+
+
+    @rhbz1661165
+    @rhel8_only
+    @internal_DHCP @con_ipv4_remove @tcpdump
+    @ipv4_dhcp_client_id_default_rhel8
+    Scenario: NM - ipv4 - ipv4 client id should default to mac with internal plugins
+    * Add connection type "ethernet" named "con_ipv4" for device "eth2"
+    * Note MAC address output for device "eth2" via ip command
+    * Run child "sudo tcpdump -i eth2 -v -n > /tmp/tcpdump.log"
+    * Bring "up" connection "con_ipv4"
+    When "empty" is not visible with command "file /tmp/tcpdump.log" in "150" seconds
+    * Bring "up" connection "con_ipv4"
+    Then Noted value is visible with command "grep 'Option 61' /tmp/tcpdump.log" in "10" seconds
+
+
+    @rhbz1661165
+    @rhel7_only
+    @internal_DHCP @con_ipv4_remove @tcpdump
+    @ipv4_dhcp_client_id_default_rhel7
+    Scenario: NM - ipv4 - ipv4 client id should default to duid with internal plugins
+    * Add connection type "ethernet" named "con_ipv4" for device "eth2"
+    * Run child "sudo tcpdump -i eth2 -v -n > /tmp/tcpdump.log"
+    * Bring "up" connection "con_ipv4"
+    When "empty" is not visible with command "file /tmp/tcpdump.log" in "150" seconds
+    * Bring "up" connection "con_ipv4"
+    Then "00:02:00:00:ab:11" is visible with command "grep 'Option 61' /tmp/tcpdump.log" in "10" seconds
+
+
     @con_ipv4_remove
     @ipv4_may-fail_yes
     Scenario: nmcli - ipv4 - may-fail - set true

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -1122,6 +1122,13 @@ def note_mac_address(context, device):
     context.noted = command_output(context, "ethtool -P %s |grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}'" % device).strip()
     print (context.noted)
 
+
+@step(u'Note MAC address output for device "{device}" via ip command')
+def note_mac_address_ip(context, device):
+    context.noted_value = command_output(context, "ip link show %s | grep 'link/ether' | awk '{print $2}'" % device).strip()
+    print (context.noted_value)
+
+
 @step(u'Noted value contains "{pattern}"')
 def note_print_property_b(context, pattern):
     assert re.search(pattern, context.noted) is not None, "Noted value does not match the pattern!"
@@ -1196,8 +1203,14 @@ def add_novice_connection(context):
     context.prompt = prompt
 
 
+@step(u'Noted value is visible with command "{command}"')
+@step(u'Noted value "{index}" is visible with command "{command}"')
 @step(u'"{pattern}" is visible with command "{command}"')
-def check_pattern_visible_with_command(context, pattern, command):
+def check_pattern_visible_with_command(context, command, pattern=None, index=None):
+    if pattern is None and index is None:
+        pattern = context.noted_value
+    if index is not None:
+        pattern = context.noted[index]
     proc = pexpect.spawn('/bin/bash', ['-c', command], maxread=100000, logfile=context.log, encoding='utf-8')
     if proc.expect([pattern, pexpect.EOF]) != 0:
         sleep(1)
@@ -1206,8 +1219,14 @@ def check_pattern_visible_with_command(context, pattern, command):
     else:
         return True
 
+@step(u'Noted value is visible with command "{command}" in "{seconds}" seconds')
+@step(u'Noted value "{index}" is visible with command "{command}" in "{seconds}" seconds')
 @step(u'"{pattern}" is visible with command "{command}" in "{seconds}" seconds')
-def check_pattern_visible_with_command_in_time(context, pattern, command, seconds):
+def check_pattern_visible_with_command_in_time(context, command, seconds, pattern=None, index=None):
+    if pattern is None and index is None:
+        pattern = context.noted_value
+    if index is not None:
+        pattern = context.noted[index]
     seconds = int(seconds)
     orig_seconds = seconds
     while seconds > 0:


### PR DESCRIPTION
add 'ipv4_dhcp_client_id_default' tests

Add tests, that with internal plugin, client ID is:
 * duid is used with NM 1.12-1.14
 * duid is used on RHEL7 
 * mac is used with NM 1.16+
 * mac is used on RHEL8

https://bugzilla.redhat.com/show_bug.cgi?id=1661165

@Build:nm-1-14