### PR TITLE
env: append logs for failed tests only

### DIFF
--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -55,7 +55,7 @@ def dump_status(context, when):
             context.log.flush()
             call(cmd, shell=True, stdout=context.log)
     else:
-        for cmd in ['ip addr', 'ip -4 route', 'ip -6 route',
+        for cmd in ['NetworkManager --version', 'ip addr', 'ip -4 route', 'ip -6 route',
             'nmcli g', 'nmcli c', 'nmcli d', 'nmcli -f IN-USE,SSID,CHAN,SIGNAL,SECURITY d w',
             'hostnamectl', 'NetworkManager --print-config', 'ps aux | grep dhclient']:
             #'nmcli con show testeth0',\
@@ -66,7 +66,7 @@ def dump_status(context, when):
         if os.path.isfile('/tmp/nm_newveth_configured'):
             context.log.write("\nVeth setup network namespace and DHCP server state:\n")
             for cmd in ['ip netns exec vethsetup ip addr', 'ip netns exec vethsetup ip -4 route',
-                        'ip netns exec vethsetup ip -6 route', 'rpm -q NetworkManager']:
+                        'ip netns exec vethsetup ip -6 route', 'ps aux | grep dnsmasq']:
                 context.log.write("--- %s ---\n" % cmd)
                 context.log.flush()
                 call(cmd, shell=True, stdout=context.log)

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -918,6 +918,11 @@ def before_scenario(context, scenario):
                 context.enforcing = True
                 call('setenforce 0', shell=True)
 
+
+        if 'tcpdump' in scenario.tags:
+            os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ TRAFFIC LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/network-traffic.log")
+            Popen("sudo tcpdump -nne -i any >> /tmp/network-traffic.log", shell=True)
+
         try:
             context.nm_pid = nm_pid()
         except CalledProcessError as e:
@@ -934,9 +939,6 @@ def before_scenario(context, scenario):
                 call("LOGNAME=root HOSTNAME=localhost gdb /usr/sbin/NetworkManager -ex 'target remote | vgdb' -ex 'monitor leak_check summary' -batch", shell=True, stdout=context.log, stderr=context.log)
 
         context.log_cursor = check_output("journalctl --lines=0 --show-cursor |awk '/^-- cursor:/ {print \"\\\"--after-cursor=\"$NF\"\\\"\"; exit}'", shell=True).decode('utf-8').strip()
-
-        os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ TRAFFIC LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/network-traffic.log")
-        Popen("sudo tcpdump -nne -i any >> /tmp/network-traffic.log", shell=True)
 
     except Exception as e:
         print(("Error in before_scenario"))
@@ -990,14 +992,15 @@ def after_scenario(context, scenario):
 
     try:
         #attach network traffic log
-        print("Attaching traffic log")
-        call("sudo kill -1 $(pidof tcpdump)", shell=True)
-        if os.stat("/tmp/network-traffic.log").st_size < 20000000:
-            traffic = open("/tmp/network-traffic.log", 'r').read()
-            if traffic:
-                context.embed('text/plain', traffic, caption="TRAFFIC")
-        else:
-            print("WARNING: 20M size exceeded in /tmp/network-traffic.log, skipping")
+        if 'tcpdump' in scenario.tags:
+            print("Attaching traffic log")
+            call("sudo kill -1 $(pidof tcpdump)", shell=True)
+            if os.stat("/tmp/network-traffic.log").st_size < 20000000:
+                traffic = open("/tmp/network-traffic.log", 'r').read()
+                if traffic:
+                    context.embed('text/plain', traffic, caption="TRAFFIC")
+            else:
+                print("WARNING: 20M size exceeded in /tmp/network-traffic.log, skipping")
 
 
         if 'netservice' in scenario.tags:
@@ -1009,7 +1012,8 @@ def after_scenario(context, scenario):
             if data:
                 context.embed('text/plain', data, caption="NETSRV")
 
-        dump_status(context, 'after %s' % scenario.name)
+        if scenario.status == 'failed':
+            dump_status(context, 'after %s' % scenario.name)
 
         if 'runonce' in scenario.tags:
             print ("---------------------------")
@@ -2014,19 +2018,19 @@ def after_scenario(context, scenario):
                     call('ip link set eth%d up' % link, shell=True)
 
 
+        if scenario.status == 'failed':
+            dump_status(context, 'after cleanup %s' % scenario.name)
 
-        dump_status(context, 'after cleanup %s' % scenario.name)
-
-        # Attach journalctl logs
-        print("Attaching NM log")
-        os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ NM LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/journal-nm.log")
-        os.system("sudo journalctl -u NetworkManager --no-pager -o cat %s >> /tmp/journal-nm.log" % context.log_cursor)
-        if os.stat("/tmp/journal-nm.log").st_size < 20000000:
-            data = open("/tmp/journal-nm.log", 'r').read()
-            if data:
-                context.embed('text/plain', data, caption="NM")
-        else:
-            print("WARNING: 20M size exceeded in /tmp/journal-nm.log, skipping")
+            # Attach journalctl logs
+            print("Attaching NM log")
+            os.system("echo '~~~~~~~~~~~~~~~~~~~~~~~~~~ NM LOG ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~' > /tmp/journal-nm.log")
+            os.system("sudo journalctl -u NetworkManager --no-pager -o cat %s >> /tmp/journal-nm.log" % context.log_cursor)
+            if os.stat("/tmp/journal-nm.log").st_size < 20000000:
+                data = open("/tmp/journal-nm.log", 'r').read()
+                if data:
+                    context.embed('text/plain', data, caption="NM")
+            else:
+                print("WARNING: 20M size exceeded in /tmp/journal-nm.log, skipping")
 
 
         if nm_pid_after is not None and context.nm_pid == nm_pid_after:

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -66,7 +66,7 @@ def dump_status(context, when):
         if os.path.isfile('/tmp/nm_newveth_configured'):
             context.log.write("\nVeth setup network namespace and DHCP server state:\n")
             for cmd in ['ip netns exec vethsetup ip addr', 'ip netns exec vethsetup ip -4 route',
-                        'ip netns exec vethsetup ip -6 route', 'ps aux | grep dnsmasq']:
+                        'ip netns exec vethsetup ip -6 route', 'rpm -q NetworkManager']:
                 context.log.write("--- %s ---\n" % cmd)
                 context.log.flush()
                 call(cmd, shell=True, stdout=context.log)


### PR DESCRIPTION
Not bundling a logs will shorten time of execution. For 1 hour in case of 1.12. from 5:45 to 4:45. 
* TCPdump is removed and will be available just via tcpdump tag
* Journal is not attached by default as quite large
* dump will not be done after passed test before and after clean up , just before test 

