### PR TITLE
add 'connection_short_info' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1366,6 +1366,8 @@ testmapper:
         feature: connection
     - connection_no_managed_device:
         feature: connection
+    - connection_short_info:
+        feature: connection
     - add_default_tap_device:
         feature: tuntap
     - add_default_tun_device:

--- a/nmcli/features/connection.feature
+++ b/nmcli/features/connection.feature
@@ -718,22 +718,36 @@ Feature: nmcli: connection
      And "eth10" is visible with command "nmcli device | grep ethernet | grep con_con"
 
 
-     @rhbz1639254
-     @ver+=1.14
-     @con_con_remove @unmanage_eth @skip_str
-     @connection_prefers_managed_devices
-     Scenario: nmcli - connection - connection activates preferably on managed devices
-      * Execute "nmcli device set eth10 managed yes"
-      * Add a new connection of type "ethernet" and options "ifname \* con-name con_con autoconnect no"
-      * Bring up connection "con_con"
-      Then "eth10" is visible with command "nmcli device | grep con_con"
+    @rhbz1639254
+    @ver+=1.14
+    @con_con_remove @unmanage_eth @skip_str
+    @connection_prefers_managed_devices
+    Scenario: nmcli - connection - connection activates preferably on managed devices
+    * Execute "nmcli device set eth10 managed yes"
+    * Add a new connection of type "ethernet" and options "ifname \* con-name con_con autoconnect no"
+    * Bring up connection "con_con"
+    Then "eth10" is visible with command "nmcli device | grep con_con"
 
 
-      @rhbz1639254
-      @ver+=1.14
-      @con_con_remove @unmanage_eth @skip_str
-      @connection_no_managed_device
-      Scenario: nmcli - connection - connection activates even on unmanaged device
-       * Add a new connection of type "ethernet" and options "ifname \* con-name con_con autoconnect no"
-       * Bring up connection "con_con"
-       Then "con_con" is visible with command "nmcli device"
+    @rhbz1639254
+    @ver+=1.14
+    @con_con_remove @unmanage_eth @skip_str
+    @connection_no_managed_device
+    Scenario: nmcli - connection - connection activates even on unmanaged device
+    * Add a new connection of type "ethernet" and options "ifname \* con-name con_con autoconnect no"
+    * Bring up connection "con_con"
+    Then "con_con" is visible with command "nmcli device"
+
+
+    @rhbz1434527
+    @ver+=1.14
+    @con_con_remove
+    @connection_short_info
+    Scenario: nmcli - connection - connection short info
+    * Add a new connection of type "ethernet" and options "ifname \* con-name con_con autoconnect no"
+    * Note the output of "nmcli -o con show con_con"
+    Then Check noted output contains "connection.id"
+    Then Check noted output does not contain "connection.zone"
+    * Note the output of "nmcli con show con_con"
+    Then Check noted output contains "connection.id"
+    Then Check noted output contains "connection.zone"

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -382,6 +382,11 @@ def check_noted_output_contains(context, pattern):
     assert re.search(pattern, context.noted_value) is not None, "Noted output does not contain the pattern %s" % pattern
 
 
+@step(u'Check noted output does not contain "{pattern}"')
+def check_noted_output_contains(context, pattern):
+    assert re.search(pattern, context.noted_value) is None, "Noted output contains the pattern %s" % pattern
+
+
 @step(u'Check if object item "{item}" has value "{value}" via print')
 def value_printed(context, item, value):
     context.prompt.sendline('print')
@@ -813,7 +818,7 @@ def delete_connection(context,connection):
     if res == 0:
         raise Exception('Got an Error while deleting connection %s' % connection)
     elif res == 1:
-        raise Exception('Deleting connecion %s timed out (95s)' % connection)
+        raise Exception('Deleting connection %s timed out (95s)' % connection)
 
 
 @step(u'Delete connection "{name}" and hit enter')


### PR DESCRIPTION
test basic functionality of `nmcli -o con show $PROFILE`

FIX: reindent end of file
FIX: harmless typo in steps.py

https://bugzilla.redhat.com/show_bug.cgi?id=1434527

@Build:nm-1-14