### PR TITLE
gen: fix connectivity checks tests

### DIFF
--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -1169,6 +1169,8 @@ def after_scenario(context, scenario):
             print ("remove connectivity checker")
             call("rm -rf /etc/NetworkManager/conf.d/99-connectivity.conf", shell=True)
             call("rm -rf /var/lib/NetworkManager/NetworkManager-intern.conf", shell=True)
+            context.execute_steps(u'* Reset /etc/hosts')
+
             reload_NM_service()
 
         if 'con' in scenario.tags:

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1578,22 +1578,22 @@ Feature: nmcli - general
 
     @rhbz1458399
     @ver+=1.8.0
-    @firewall @connectivity @con_general_remove @eth0
+    @connectivity @con_general_remove @eth0
     @connectivity_check
     Scenario: NM - general - connectivity check
     * Add a new connection of type "ethernet" and options "ifname eth0 con-name con_general autoconnect no ipv6.method ignore"
     * Bring up connection "con_general"
     When "activated" is visible with command "nmcli -g GENERAL.STATE con show con_general" in "20" seconds
      And "full" is visible with command "nmcli  -g CONNECTIVITY g" in "70" seconds
-    * Execute "firewall-cmd --panic-on"
+     * Append "1.2.3.4 static.redhat.com" to file "/etc/hosts"
     When "limited" is visible with command "nmcli  -g CONNECTIVITY g" in "70" seconds
-    * Execute "firewall-cmd --panic-off"
+     * Reset /etc/hosts
     Then "full" is visible with command "nmcli  -g CONNECTIVITY g" in "70" seconds
 
 
     @rhbz1458399
     @ver+=1.8.0
-    @firewall @connectivity @con_general_remove @delete_testeth0 @restart
+    @connectivity @con_general_remove @delete_testeth0 @restart
     @disable_connectivity_check
     Scenario: NM - general - disable connectivity check
     * Execute "rm -rf /etc/NetworkManager/conf.d/99-connectivity.conf"
@@ -1602,7 +1602,7 @@ Feature: nmcli - general
     * Bring up connection "con_general"
     When "activated" is visible with command "nmcli -g GENERAL.STATE con show con_general" in "20" seconds
      And "full" is visible with command "nmcli  -g CONNECTIVITY g"
-    * Execute "firewall-cmd --panic-on"
+    * Append "1.2.3.4 static.redhat.com" to file "/etc/hosts"
     Then "full" is visible with command "nmcli  -g CONNECTIVITY g" for full "70" seconds
 
 
@@ -1626,7 +1626,7 @@ Feature: nmcli - general
 
     @rhbz1534477
     @ver+=1.10
-    @firewall @connectivity @con_general_remove @delete_testeth0 @restart @long
+    @connectivity @con_general_remove @delete_testeth0 @restart @long
     @manipulate_connectivity_check_via_dbus
     Scenario: dbus - general - connectivity check manipulation
     * Add a new connection of type "ethernet" and options "ifname eth0 con-name con_general autoconnect no ipv6.method ignore"
@@ -1635,14 +1635,15 @@ Feature: nmcli - general
      And "full" is visible with command "nmcli -g CONNECTIVITY g" in "70" seconds
     # VVV Turn off connectivity check
     * Execute "busctl set-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager ConnectivityCheckEnabled 'b' 0"
-    * Execute "sleep 1 && firewall-cmd --panic-on"
+    #* Execute "sleep 1 && firewall-cmd --panic-on"
+    * Append "1.2.3.4 static.redhat.com" to file "/etc/hosts"
     When "false" is visible with command "busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager ConnectivityCheckEnabled"
      And "full" is visible with command "nmcli  -g CONNECTIVITY g" for full "70" seconds
     # VVV Turn on connectivity check
     * Execute "busctl set-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager ConnectivityCheckEnabled 'b' 1"
     When "true" is visible with command "busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager ConnectivityCheckEnabled"
      And "limited" is visible with command "nmcli  -g CONNECTIVITY g" in "70" seconds
-    * Execute "firewall-cmd --panic-off"
+     * Reset /etc/hosts
     Then "full" is visible with command "nmcli  -g CONNECTIVITY g" in "70" seconds
 
 

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1586,7 +1586,7 @@ Feature: nmcli - general
     When "activated" is visible with command "nmcli -g GENERAL.STATE con show con_general" in "20" seconds
      And "full" is visible with command "nmcli  -g CONNECTIVITY g" in "70" seconds
      * Append "1.2.3.4 static.redhat.com" to file "/etc/hosts"
-    When "limited" is visible with command "nmcli  -g CONNECTIVITY g" in "70" seconds
+    When "limited" is visible with command "nmcli  -g CONNECTIVITY g" in "100" seconds
      * Reset /etc/hosts
     Then "full" is visible with command "nmcli  -g CONNECTIVITY g" in "70" seconds
 
@@ -1642,7 +1642,7 @@ Feature: nmcli - general
     # VVV Turn on connectivity check
     * Execute "busctl set-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager ConnectivityCheckEnabled 'b' 1"
     When "true" is visible with command "busctl get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager ConnectivityCheckEnabled"
-     And "limited" is visible with command "nmcli  -g CONNECTIVITY g" in "70" seconds
+     And "limited" is visible with command "nmcli  -g CONNECTIVITY g" in "100" seconds
      * Reset /etc/hosts
     Then "full" is visible with command "nmcli  -g CONNECTIVITY g" in "70" seconds
 

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -56,6 +56,12 @@ def append_to_ifcfg(context, line, name):
     cmd = 'sudo echo "%s" >> /etc/sysconfig/network-scripts/ifcfg-%s' % (line, name)
     command_code(context, cmd)
 
+@step('Reset /etc/hosts')
+def reset_hosts(context):
+    cmd = "echo '127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4' > /etc/hosts"
+    command_code(context, cmd)
+    cmd = "echo '::1         localhost localhost.localdomain localhost6 localhost6.localdomain6' >> /etc/hosts"
+    command_code(context, cmd)
 
 # @step(u'Add connection for a type "{typ}" named "{name}"')
 # def add_connection(context, typ, name):


### PR DESCRIPTION
Append/remove 1.2.3.4 static.redhat.com to /etc/hosts to make
checker unreachable instead of doing firewalld --panic-on/off.