### PR TITLE
add 'nmcli_novice_print_types' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1164,6 +1164,8 @@ testmapper:
         feature: general
     - editor_print_info:
         feature: general
+    - nmcli_novice_print_types:
+        feature: general
     - openvswitch_interface_recognized:
         feature: ovs
     - openvswitch_ignore_ovs_network_setup:

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -2010,3 +2010,13 @@ Feature: nmcli - general
     * Submit "print" in editor
     Then "connection.id:" appeared in editor
     * Quit editor
+
+
+    @rhbz1588952
+    @ver+=1.14
+    @nmcli_novice_print_types
+    Scenario: nmcli - general - print availiable connection types in connection assistant
+    * Open wizard for adding new connection
+    * Expect "Connection type"
+    * Submit "<double_tab>"
+    Then Expect "adsl.*bluetooth.*bond.*bridge"

--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -1862,6 +1862,10 @@ def submit(context, what):
         context.prompt.sendline(context.noted)
     elif what == '<enter>':
         context.prompt.send("\n")
+    elif what == '<tab>':
+        context.prompt.send("\t")
+    elif what == '<double_tab>':
+        context.prompt.send("\t\t")
     else:
         context.prompt.sendline(what)
 


### PR DESCRIPTION
Add check, that connection assistant prints connection type 
possibilities after double tab

https://bugzilla.redhat.com/show_bug.cgi?id=1588952

@Build:nm-1-14