### PR TITLE
add 'libnm_snapshot_destroy_after_rollback' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1154,6 +1154,8 @@ testmapper:
         feature: general
     - libnm_snapshot_rollback_soft_device:
         feature: general
+    - libnm_snapshot_destroy_after_rollback:
+        feature: general
     - autoconnect_no_secrets_prompt:
         feature: general
     - ifup_ifdown_scripts_rhel8:

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1940,6 +1940,17 @@ Feature: nmcli - general
     Then Check slave "eth9" in bond "gen-bond" in proc
 
 
+    @rhbz1574565
+    @ver+=1.12
+    @gen-bond_remove
+    @libnm_snapshot_destroy_after_rollback
+    Scenario: NM - general - snapshot and destroy checkpoint
+    * Execute "tmp/libnm_snapshot_checkpoint.py create 5"
+    Then Finish "tmp/libnm_snapshot_checkpoint.py destroy last 1"
+    * Execute "tmp/libnm_snapshot_checkpoint.py create 5"
+    Then Finish "! tmp/libnm_snapshot_checkpoint.py destroy last 7"
+
+
     @rhbz1553113
     @ver+=1.12
     @con_general_remove


### PR DESCRIPTION
Add test, that deystroing checkpoint object before rollback succeds, and 
that after rollback it fails.

It is important to exit with error, when destroying checkpoint object 
which is alredy rollbacked or destroyed.

https://bugzilla.redhat.com/show_bug.cgi?id=1574565