### PR TITLE
add 'nmcli_modify_altsubject-matches' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1166,6 +1166,8 @@ testmapper:
         feature: general
     - nmcli_novice_print_types:
         feature: general
+    - nmcli_modify_altsubject-matches:
+        feature: general
     - openvswitch_interface_recognized:
         feature: ovs
     - openvswitch_ignore_ovs_network_setup:

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -2023,3 +2023,19 @@ Feature: nmcli - general
     * Expect "Connection type"
     * Submit "<double_tab>"
     Then Expect "adsl.*bluetooth.*bond.*bridge"
+
+
+    @rhbz1671200
+    @ver+=1.14
+    @con_general_remove
+    @nmcli_modify_altsubject-matches
+    Scenario: nmcli - general - modification of 802-1x.altsubject-matches sometimes leads to nmcli SIGSEGV
+    * Add a new connection of type "ethernet" and options "ifname \* con-name con_general autoconnect no 802-1x.eap peap 802-1x.identity aaa 802-1x.phase2-auth mschap"
+    Then Finish "nmcli con mod con_general 802-1x.altsubject-matches '/something/very/long/should/be/there/at/least/fortyfour/characters' "
+     And Finish "nmcli con mod con_general 802-1x.altsubject-matches '/something/very/long/should/be/there/at/least/fortyfour/characters' "
+     And Finish "nmcli con mod con_general 802-1x.altsubject-matches '/something/very/long/should/be/there/at/least/fortyfour/characters' "
+     And Finish "nmcli con mod con_general 802-1x.altsubject-matches '/something/very/long/should/be/there/at/least/fortyfour/characters' "
+     And Finish "nmcli con mod con_general 802-1x.altsubject-matches '/something/very/long/should/be/there/at/least/fortyfour/characters' "
+     And Finish "nmcli con mod con_general 802-1x.altsubject-matches '/something/very/long/should/be/there/at/least/fortyfour/characters' "
+     And Finish "nmcli con mod con_general 802-1x.altsubject-matches '/something/very/long/should/be/there/at/least/fortyfour/characters' "
+     And Finish "nmcli con mod con_general 802-1x.altsubject-matches '/something/very/long/should/be/there/at/least/fortyfour/characters' "


### PR DESCRIPTION
nmcli sometimes crash with SIGSEGV when modifying 
'802-1x.altsubject-matches' property of a connection

The test changes this property 8 times, to increase probability of 
SIGSEGV

https://bugzilla.redhat.com/show_bug.cgi?id=1576490

@Build:nm-1-14