### PR TITLE
ovs: add 'restart_NM_with_mixed_setup' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1190,6 +1190,8 @@ testmapper:
         feature: ovs
     - NM_reboot_openvswitch_vlan_configuration:
         feature: ovs
+    - restart_NM_with_mixed_setup:
+        feature: ovs
     - dispatcher_preup_and_up:
         feature: dispatcher
     - dispatcher_predown_and_down:

--- a/nmcli/features/ovs.feature
+++ b/nmcli/features/ovs.feature
@@ -307,3 +307,27 @@ Feature: nmcli - ovs
      And "192.168.100.*\/24" is visible with command "ip a s iface0"
      And "fe80::" is visible with command "ip a s iface0"
      And "default via 192.168.100.1 dev iface0 proto dhcp metric 800" is visible with command "ip r"
+
+
+     @rhbz1676551
+     @ver+=1.10
+     @openvswitch @restart @vlan @bond @slaves
+     @restart_NM_with_mixed_setup
+     Scenario: NM -  openvswitch - restart NM when OVS is unmanaged
+     * Add a new connection of type "bond" and options "ifname nm-bond con-name bond0"
+     * Add a new connection of type "vlan" and options "con-name vlan1 dev nm-bond id 101 ipv6.method ignore ipv4.method manual ipv4.method manual ipv4.addresses 10.200.208.98/16  ipv4.routes 224.0.0.0/4"
+     * Add a new connection of type "vlan" and options "con-name vlan2 dev nm-bond id 201 ipv6.method ignore ipv4.method manual ipv4.addresses 10.201.0.13/24 ipv4.gateway 10.201.0.1"
+     * Add a new connection of type "ethernet" and options "ifname eth2 master nm-bond con-name bond0.0"
+     * Add a new connection of type "ethernet" and options "ifname eth3 master nm-bond con-name bond0.1"
+     * Execute "ovs-vsctl add-br ovsbridge0 -- add-port ovsbridge0 nm-bond"
+     When "activated" is visible with command "nmcli -g GENERAL.STATE con show bond0" in "40" seconds
+     And "224.0.0.0/4 dev nm-bond.101" is visible with command "ip r"
+     And "10.200.0.0/16 dev nm-bond.101" is visible with command "ip r"
+     And "10.201.0.0/24 dev nm-bond.201" is visible with command "ip r"
+     And "default via" is visible with command "ip r |grep nm-bond"
+     * Restart NM
+     When "activated" is visible with command "nmcli -g GENERAL.STATE con show bond0" in "40" seconds
+     And "224.0.0.0/4 dev nm-bond.101" is visible with command "ip r"
+     And "10.200.0.0/16 dev nm-bond.101" is visible with command "ip r"
+     And "10.201.0.0/24 dev nm-bond.201" is visible with command "ip r"
+     And "default via" is visible with command "ip r |grep nm-bond"

--- a/nmcli/features/ovs.feature
+++ b/nmcli/features/ovs.feature
@@ -310,8 +310,8 @@ Feature: nmcli - ovs
 
 
      @rhbz1676551
-     @ver+=1.10
-     @openvswitch @restart @vlan @bond @slaves
+     @ver+=1.12
+     @openvswitch @restart @vlan @bond @slaves @not_in_rhel8
      @restart_NM_with_mixed_setup
      Scenario: NM -  openvswitch - restart NM when OVS is unmanaged
      * Add a new connection of type "bond" and options "ifname nm-bond con-name bond0"


### PR DESCRIPTION
Add a test for making sure routes are readded correctly where bond
and vlans are added into OVS via ovs-vsctl and not NM.

https://bugzilla.redhat.com/show_bug.cgi?id=1676551

@Build:nm-1-16
