### PR TITLE
Increase stability of step 'Check bond "{bond}" link state is "{state}"'

### DIFF
--- a/nmcli/features/steps/steps.py
+++ b/nmcli/features/steps/steps.py
@@ -549,16 +549,15 @@ def check_bond_state(context, bond, state):
 
 @step(u'Check bond "{bond}" link state is "{state}"')
 def check_bond_link_state(context, bond, state):
-    ret = False
     if os.system('ls /proc/net/bonding/%s' %bond) != 0 and state == "down":
         return
-    i = 4
+    i = 40
     while i > 0:
         child = pexpect.spawn('cat /proc/net/bonding/%s' % (bond), encoding='utf-8')
         if child.expect(["MII Status: %s" %  state, pexpect.EOF]) == 0:
             return
         else:
-            sleep(1)
+            sleep(0.2)
             i-=1
     assert child.expect(["MII Status: %s" %  state, pexpect.EOF]) == 0, "%s is not in %s link state" % (bond, state)
 

--- a/nmtui/features/steps/steps.py
+++ b/nmtui/features/steps/steps.py
@@ -542,7 +542,14 @@ def check_bond_state(context, bond, state):
 def check_bond_link_state(context, bond, state):
     if os.system('ls /proc/net/bonding/%s' %bond) != 0 and state == "down":
         return
-    child = pexpect.spawn('cat /proc/net/bonding/%s' % (bond))
+    i = 40
+    while i > 0:
+        child = pexpect.spawn('cat /proc/net/bonding/%s' % (bond), encoding='utf-8')
+        if child.expect(["MII Status: %s" %  state, pexpect.EOF]) == 0:
+            return
+        else:
+            sleep(0.2)
+            i-=1
     assert child.expect(["MII Status: %s" %  state, pexpect.EOF]) == 0, "%s is not in %s link state" % (bond, state)
 
 


### PR DESCRIPTION
Step is sometimes failing, increased number of tries and lowered timeout 
between checks (to increase performance)

This is because step checks bond state in procfs, and it is kernel 
dependent, when bond state changes there.

Also, updated nmtui step with nmcli version (more stable)