### PR TITLE
Add simple wireguard test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1260,6 +1260,8 @@ testmapper:
         feature: vpn
     - iptunnel_restart:
         feature: vpn
+    - wireguard_activate_connection:
+        feature: vpn
     - openvpn_ipv4:
         feature: openvpn
     - openvpn_ipv4_neverdefault:

--- a/nmcli/features/environment.py
+++ b/nmcli/features/environment.py
@@ -758,6 +758,13 @@ def before_scenario(context, scenario):
             print("iptunnel setup")
             call('sh prepare/iptunnel.sh', shell=True)
 
+        if 'wireguard' in scenario.tags:
+            print("----------------------------")
+            print("wireguard setup")
+            rc = call('sh prepare/wireguard.sh', shell=True)
+            if rc != 0:
+                print("wireguard setup failed with exitcode: %d" % rc)
+                sys.exit(rc)
 
         # if 'macsec' in scenario.tags:
         #     print("---------------------------")
@@ -1667,6 +1674,11 @@ def after_scenario(context, scenario):
             print("----------------------------")
             print("iptunnel teardown")
             call('sh prepare/iptunnel.sh teardown', shell=True)
+
+        if 'wireguard' in scenario.tags:
+            print("----------------------------")
+            print("remove wireguard connection")
+            call('nmcli con del wireguard', shell=True)
 
         if 'scapy' in scenario.tags:
             print ("---------------------------")

--- a/nmcli/features/vpn.feature
+++ b/nmcli/features/vpn.feature
@@ -119,3 +119,20 @@
     * Restart NM
     Then Bring "down" connection "gre1"
     Then Bring "down" connection "ipip1"
+
+
+    @ver+=1.16
+    @wireguard @not_in_rhel7
+    @wireguard_activate_connection
+    Scenario: nmcli - vpn - create and activate wireguard connection
+    * Add a new connection of type "wireguard" and options "ifname nm-wireguard con-name wireguard wireguard.private-key qOdhat/redhat/redhat/redhat/redhat/redhatUE= wireguard.listen-port 23456 ipv4.method manual ipv4.addresses 172.25.17.1/24 "
+    * Bring "up" connection "wireguard"
+    Then "qOdhat/redhat/redhat/redhat/redhat/redhatUE=" is visible with command "sudo WG_HIDE_KEYS=never wg | grep 'private key:'" in "10" seconds
+     And "23456" is visible with command "sudo WG_HIDE_KEYS=never wg | grep 'port:'" in "10" seconds
+     And "172.25.17.1/24" is visible with command "ip address show dev nm-wireguard"
+    * Modify connection "wireguard" changing options "wireguard.private-key qOdhat/redhat/REDHAT/redhat/redhat/redhatUE= wireguard.listen-port 14456 ipv4.addresses 172.25.17.4/24 wireguard.mtu 1250"
+    * Bring "up" connection "wireguard"
+    Then "qOdhat/redhat/REDHAT/redhat/redhat/redhatUE=" is visible with command "sudo WG_HIDE_KEYS=never wg | grep 'private key:'" in "10" seconds
+     And "14456" is visible with command "sudo WG_HIDE_KEYS=never wg | grep 'port:'" in "10" seconds
+     And "172.25.17.4/24" is visible with command "ip address show dev nm-wireguard"
+     And "mtu 1250" is visible with command "ip address show dev nm-wireguard"

--- a/prepare/wireguard.sh
+++ b/prepare/wireguard.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+# test whether wireguard module and utility are already installed
+if which wg > /dev/null && lsmod | grep -q wireguard ; then
+    echo "wireguard already configured"
+    exit 0
+fi
+
+# install tools required for build
+sudo yum -y install libmnl-devel elfutils-libelf-devel kernel-devel-$(uname -r) pkg-config gcc git
+
+cd tmp/
+
+# cleanum and clone repo
+rm -rf WireGuard
+git clone https://git.zx2c4.com/WireGuard
+cd WireGuard
+
+# checkout version 0.0.20190227 (safer to use comit hash than version - thaller)
+git checkout ab146d92c353cb111b31ea8b672d4849fcbe8397
+
+# build
+cd src
+make
+sudo make install
+
+# check that everything works
+if which wg > /dev/null ; then
+    exit 0
+else
+    echo "wireguard utility 'wg' not found"
+    exit 1
+fi
+
+
+if lsmod | grep -q wireguard ; then
+    exit 0
+else
+    echo "module wireguard not loaded"
+    exit 1
+fi


### PR DESCRIPTION
Wireguard is so far working only on RHEL 8. On RHEL 7 wireguard module 
is unable to compile, due to older kernel.

Also, at least NM 1.16 required, to be able to add wireguard connection.

@Build:nm-1-16