### PR TITLE
tc: add 'remove_root_value" test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1412,6 +1412,8 @@ testmapper:
         feature: tc
     - set_pfifo_fast_queue:
         feature: tc
+    - remove_root_value:
+        feature: tc
     - simwifi_wpa2psk_profile:
         feature: wifi_hwsim
     - simwifi_wpa2psk_no_profile:
@@ -1447,7 +1449,7 @@ testmapper:
     - wifi_dbus_bitrate_property_name:
         feature: wifi_hwsim
     - simwifi_p2p_connect:
-        feature: wifi_hwsim        
+        feature: wifi_hwsim
     - gsm_sim_create_assisted_connection:
         feature: gsm_sim
     - gsm_sim_create_default_connection:

--- a/nmcli/features/tc.feature
+++ b/nmcli/features/tc.feature
@@ -9,20 +9,20 @@
 
     @rhbz909236
     @ver+=1.10
-    @con_tc_remove
+    @con_tc_remove @eth0
     @set_fq_codel_queue
     Scenario: nmcli - tc - set fq_codel
-    * Add a new connection of type "ethernet" and options "ifname eth9 con-name con_tc autoconnect no tc.qdiscs 'root fq_codel'"
+    * Add a new connection of type "ethernet" and options "ifname eth0 con-name con_tc autoconnect no tc.qdiscs 'root fq_codel'"
     * Bring "up" connection "con_tc"
     Then "fq_codel" is visible with command "ip a s eth0" in "5" seconds
 
 
     @rhbz909236
     @ver+=1.10
-    @con_tc_remove
+    @con_tc_remove @eth0
     @set_pfifo_fast_queue
     Scenario: nmcli - tc - set pfifo_fast
-    * Add a new connection of type "ethernet" and options "ifname eth9 con-name con_tc autoconnect no tc.qdiscs 'root fq_codel'"
+    * Add a new connection of type "ethernet" and options "ifname eth0 con-name con_tc autoconnect no tc.qdiscs 'root fq_codel'"
     * Execute "nmcli con modify con_tc tc.qdiscs 'root pfifo_fast'"
     * Bring "up" connection "con_tc"
     Then "pfifo_fast" is visible with command "ip a s eth0" in "5" seconds
@@ -30,10 +30,10 @@
 
     @rhbz1546805
     @ver+=1.16
-    @con_tc_remove
+    @con_tc_remove @eth0
     @remove_root_value
     Scenario: nmcli - tc - remove root value
-    * Add a new connection of type "ethernet" and options "ifname eth9 con-name con_tc autoconnect no tc.qdiscs 'root pfifo_fast'"
+    * Add a new connection of type "ethernet" and options "ifname eth0 con-name con_tc autoconnect no tc.qdiscs 'root pfifo_fast'"
     * Bring "up" connection "con_tc"
     * Open editor for connection "con_tc"
     * Submit "set tc.qdiscs" in editor

--- a/nmcli/features/tc.feature
+++ b/nmcli/features/tc.feature
@@ -9,20 +9,35 @@
 
     @rhbz909236
     @ver+=1.10
-    @con_tc_remove @eth0
+    @con_tc_remove
     @set_fq_codel_queue
     Scenario: nmcli - tc - set fq_codel
-    * Add a new connection of type "ethernet" and options "ifname eth0 con-name con_tc autoconnect no tc.qdiscs 'root fq_codel'"
+    * Add a new connection of type "ethernet" and options "ifname eth9 con-name con_tc autoconnect no tc.qdiscs 'root fq_codel'"
     * Bring "up" connection "con_tc"
     Then "fq_codel" is visible with command "ip a s eth0" in "5" seconds
 
 
     @rhbz909236
     @ver+=1.10
-    @con_tc_remove @eth0
+    @con_tc_remove
     @set_pfifo_fast_queue
     Scenario: nmcli - tc - set pfifo_fast
-    * Add a new connection of type "ethernet" and options "ifname eth0 con-name con_tc autoconnect no tc.qdiscs 'root fq_codel'"
+    * Add a new connection of type "ethernet" and options "ifname eth9 con-name con_tc autoconnect no tc.qdiscs 'root fq_codel'"
     * Execute "nmcli con modify con_tc tc.qdiscs 'root pfifo_fast'"
     * Bring "up" connection "con_tc"
     Then "pfifo_fast" is visible with command "ip a s eth0" in "5" seconds
+
+
+    @rhbz1546805
+    @ver+=1.16
+    @con_tc_remove
+    @remove_root_value
+    Scenario: nmcli - tc - remove root value
+    * Add a new connection of type "ethernet" and options "ifname eth9 con-name con_tc autoconnect no tc.qdiscs 'root pfifo_fast'"
+    * Bring "up" connection "con_tc"
+    * Open editor for connection "con_tc"
+    * Submit "set tc.qdiscs" in editor
+    * Enter in editor
+    * Save in editor
+    * Quit editor
+    Then Prompt is not running


### PR DESCRIPTION
Check that we can save in nmcli when tc.qdiscs is cleared.
https://bugzilla.redhat.com/show_bug.cgi?id=1546805