### PR TITLE
ipv4/6: add 'ipv4/6_manual_addr_before_dhcp' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -559,6 +559,8 @@ testmapper:
         feature: ipv6
     - ipv6_duid:
         feature: ipv6
+    - ipv6_manual_addr_before_dhcp:
+        feature: ipv6
     - nmcli_general_correct_profile_activated_after_restart:
         feature: ipv4
     - nmcli_general_profile_pickup_doesnt_break_network:
@@ -767,6 +769,8 @@ testmapper:
     - ipv4_dhcp_client_id_change_lease_restart:
         feature: ipv4
     - ipv4_prefix_route_missing_after_ip_link_down_up:
+        feature: ipv4
+    - ipv4_manual_addr_before_dhcp:
         feature: ipv4
     - vlan_add_default_device:
         feature: vlan


### PR DESCRIPTION
Check that NM sets addresses immediatelly and doesn't wait for DHCP
ones.

https://bugzilla.redhat.com/show_bug.cgi?id=1369905

still seeing
https://bugzilla.redhat.com/show_bug.cgi?id=1695070