### PR TITLE
FIX: version in 'libnm_async_activation_cancelable_no_crash' test

### DIFF
--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -1776,7 +1776,7 @@ Feature: nmcli - general
 
 
     @rhbz1643085 @rhbz1642625
-    @ver+=1.14
+    @ver+=1.10
     @con_general_remove
     @libnm_async_activation_cancelable_no_crash
     Scenario: NM - general - cancelation of libnm async activation - should not crash


### PR DESCRIPTION
the bug was fixed also in older versions of NM, runngin since version 1.10 instead of 1.14

already tested, should not fail