### PR TITLE
gsm: don't expect being prompted for gsm.apm in @gsm_sim_create_assis…

### DIFF
--- a/nmcli/features/gsm_sim.feature
+++ b/nmcli/features/gsm_sim.feature
@@ -2,6 +2,7 @@ Feature: nmcli: gsm
 
 
     @ver+=1.12.0
+    @ver-=1.17.1
     @gsm_sim
     @gsm_sim_create_assisted_connection
     Scenario: nmcli - gsm_sim - create an assisted connection
@@ -13,6 +14,24 @@ Feature: nmcli: gsm
     * Enter in editor
     * Expect "APN"
     * Submit "internet" in editor
+    * Expect "Do you want to provide them\? \(yes\/no\) \[yes\]"
+    * Submit "no" in editor
+    * Dismiss IP configuration in editor
+    * Dismiss Proxy configuration in editor
+    Then "GENERAL.STATE:.*activated" is visible with command "nmcli con show gsm" in "60" seconds
+    And "default" is visible with command "ip r |grep 700"
+
+
+    @ver+=1.17.2
+    @gsm_sim
+    @gsm_sim_create_assisted_connection
+    Scenario: nmcli - gsm_sim - create an assisted connection
+    Given "gsm" is visible with command "nmcli device status | grep -v unmanaged" in "60" seconds
+    * Open wizard for adding new connection
+    * Expect "Connection type"
+    * Submit "gsm" in editor
+    * Expect "Interface name"
+    * Enter in editor
     * Expect "Do you want to provide them\? \(yes\/no\) \[yes\]"
     * Submit "no" in editor
     * Dismiss IP configuration in editor


### PR DESCRIPTION
…ted_connection

gsm.apn is not a required parameter of the setting. This changed
upstream in commit [1], shortly after "1.17.2-dev".

The @gsm_sim_create_assisted_connection test is currently failing on master.
Fix the test for that.

[1] https://cgit.freedesktop.org/NetworkManager/NetworkManager/commit/?id=4ddc2bb7664156a1cad9d47b24a7e874713cbc52