### PR TITLE
add 'libnm_get_dns_crash' test

### DIFF
--- a/mapper.yaml
+++ b/mapper.yaml
@@ -1176,6 +1176,8 @@ testmapper:
         feature: general
     - nmcli_modify_altsubject-matches:
         feature: general
+    - libnm_get_dns_crash:
+        feature: general
     - openvswitch_interface_recognized:
         feature: ovs
     - openvswitch_ignore_ovs_network_setup:

--- a/nmcli/features/general.feature
+++ b/nmcli/features/general.feature
@@ -2059,3 +2059,10 @@ Feature: nmcli - general
      And Finish "nmcli con mod con_general 802-1x.altsubject-matches '/something/very/long/should/be/there/at/least/fortyfour/characters' "
      And Finish "nmcli con mod con_general 802-1x.altsubject-matches '/something/very/long/should/be/there/at/least/fortyfour/characters' "
      And Finish "nmcli con mod con_general 802-1x.altsubject-matches '/something/very/long/should/be/there/at/least/fortyfour/characters' "
+
+
+    @rhbz1689054
+    @ver+=1.16
+    @libnm_get_dns_crash
+    Scenario: nmcli - general - libnm crash when getting nmclient.props.dns_configuration
+    Then Finish "python tmp/repro_1689054.py"

--- a/tmp/repro_1689054.py
+++ b/tmp/repro_1689054.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+# author: Gris Ge <fge@redhat.com>
+# https://bugzilla.redhat.com/show_bug.cgi?id=1689054
+
+import gi                           # pylint: disable=import-error
+import time
+from subprocess import check_output
+
+gi.require_version('NM', '1.0')     # NOQA: F402
+from gi.repository import Gio, GLib, NM  # pylint: disable=import-error
+
+nmclient = NM.Client.new()
+
+print(nmclient.props.dns_configuration)


### PR DESCRIPTION
Add test, that there is no crash while getting 
nmclient.props.dns_configuration in python with libnm

https://bugzilla.redhat.com/show_bug.cgi?id=1689054

@Build:nm-1-16