### PR TITLE
bond: add new bond_mac_reconnect_preserve for 1.16.2+

### DIFF
--- a/nmcli/features/bond.feature
+++ b/nmcli/features/bond.feature
@@ -350,7 +350,7 @@
 
 
     @rhbz1472965
-    @ver+=1.8.0
+    @ver+=1.8.0 @ver-=1.16.1
     @slaves @bond
     @bond_mac_reconnect_preserve
     Scenario: nmcli - bond - mac reconnect preserve
@@ -359,6 +359,28 @@
     * Add a new connection of type "bond" and options "con-name bond0"
     # Workaround for bug 1649394, just remove the sleep 3
     * Execute "sleep 5; nmcli con up bond0.0"
+    When "nm-bond:connected:bond0" is visible with command "nmcli -t -f DEVICE,STATE,CONNECTION device" in "40" seconds
+    #* Bring "up" connection "bond0.0"
+    * Note the output of "nmcli -g GENERAL.HWADDR device show eth1" as value "new_eth1"
+    * Note the output of "nmcli -g GENERAL.HWADDR device show nm-bond" as value "old_nm-bond"
+    * Bring "up" connection "bond0"
+    When "nm-bond:connected:bond0" is visible with command "nmcli -t -f DEVICE,STATE,CONNECTION device" in "40" seconds
+    * Note the output of "nmcli -g GENERAL.HWADDR device show eth1" as value "newest_eth1"
+    * Note the output of "nmcli -g GENERAL.HWADDR device show nm-bond" as value "new_nm-bond"
+    Then Check noted values "old_eth1" and "new_eth1" are the same
+     And Check noted values "newest_eth1" and "new_eth1" are the same
+     And Check noted values "old_nm-bond" and "old_nm-bond" are the same
+
+
+    @rhbz1472965 @1649394
+    @ver+=1.16.2
+    @slaves @bond
+    @bond_mac_reconnect_preserve
+    Scenario: nmcli - bond - mac reconnect preserve
+    * Note the output of "nmcli -g GENERAL.HWADDR device show eth1" as value "old_eth1"
+    * Add a new connection of type "bond-slave" and options "con-name bond0.0 ifname eth1 master nm-bond"
+    * Add a new connection of type "bond" and options "con-name bond0"
+    * Execute "nmcli con up bond0.0"
     When "nm-bond:connected:bond0" is visible with command "nmcli -t -f DEVICE,STATE,CONNECTION device" in "40" seconds
     #* Bring "up" connection "bond0.0"
     * Note the output of "nmcli -g GENERAL.HWADDR device show eth1" as value "new_eth1"


### PR DESCRIPTION
Check that no race conditions are hit. When upping connections.

https://bugzilla.redhat.com/show_bug.cgi?id=1649394

@Build:nm-1-16